### PR TITLE
Corrected an error in the description of ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,11 @@ name: Node.js AntPickax CI
 #
 on:
   push:
-    branches:
-      - '**'
-      - '!gh-pages'
+    branches-ignore:
+      - 'gh-pages'
+    tags:
+      - '*'
   pull_request:
-    branches:
-      - '**'
-      - '!gh-pages'
   #
   # CRON event is fire on every sunday(UTC).
   #


### PR DESCRIPTION
## Relevant Issue (if applicable)
#24 

## Details
If we use branch-ignore or branch(!), the tag trigger will be ignored.
To avoid this, I had to use `tags` and write to allow tags.
