### PR TITLE
Fixed jose require path for updating jose version

### DIFF
--- a/routes/lib/userValidateOidc.js
+++ b/routes/lib/userValidateOidc.js
@@ -23,7 +23,7 @@
 
 var r3util		= require('./libr3util');
 var	oidc		= require('../oidc');
-var { decode }	= require('jose/util/base64url');
+var { decode }	= require('jose').base64url;
 
 //
 // rawGetOtherToken

--- a/routes/oidc.js
+++ b/routes/oidc.js
@@ -113,9 +113,9 @@ var	passport		= require('passport');
 var	session			= require('express-session');
 
 var	{ custom, Issuer, Strategy }= require('openid-client');
-var	{ decode }					= require('jose/util/base64url');
-var	{ createRemoteJWKSet }		= require('jose/jwks/remote');
-var	{ jwtVerify }				= require('jose/jwt/verify');
+var	{ decode }					= require('jose').base64url;
+var	{ createRemoteJWKSet }		= require('jose');
+var	{ jwtVerify }				= require('jose');
 
 //
 // Configration for OIDC


### PR DESCRIPTION
## Relevant Issue (if applicable)
#42 

## Details
With the update of #42, the version of the `jose` package has been upgraded.
Therefore, it was necessary to change the `require` of the `jose` package, and that was fixed.
