### PR TITLE
Updated to MUI(material-ui) v5 and React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,11 @@
   "name": "k2hr3-app",
   "version": "1.0.6",
   "dependencies": {
-    "@material-ui/core": "^4.12.4",
-    "@material-ui/icons": "^4.11.3",
+    "@emotion/react": "^11.9.3",
+    "@emotion/styled": "^11.9.3",
+    "@mui/icons-material": "^5.8.4",
+    "@mui/material": "^5.8.5",
+    "@mui/styles": "^5.8.4",
     "ajv": "^8.11.0",
     "body-parser": "^1.20.0",
     "config": "^3.3.7",
@@ -20,7 +23,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-transition-group": "^4.4.2",
-    "rotating-file-stream": "^2.1.6",
+    "rotating-file-stream": "^3.0.4",
     "serve-favicon": "^2.5.0",
     "whatwg-fetch": "^3.6.2"
   },
@@ -40,25 +43,26 @@
     "views": "views"
   },
   "devDependencies": {
-    "@babel/core": "^7.18.2",
+    "@babel/core": "^7.18.5",
+    "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-proposal-class-properties": "^7.17.12",
     "@babel/plugin-proposal-decorators": "^7.18.2",
     "@babel/preset-env": "^7.18.2",
     "@babel/preset-react": "^7.17.12",
-    "@babel/eslint-parser": "^7.18.2",
     "babel-jest": "^28.1.1",
     "babel-loader": "^8.2.5",
     "css-loader": "^6.7.1",
-    "eslint": "^8.17.0",
+    "eslint": "^8.18.0",
     "eslint-plugin-react": "^7.30.0",
     "jest": "^28.1.1",
+    "jest-environment-jsdom": "^28.1.1",
     "license-checker": "^25.0.1",
     "publish-please": "^5.5.2",
     "react-test-context-provider": "^2.2.0",
     "react-test-renderer": "^17.0.2",
     "style-loader": "^3.3.1",
     "webpack": "^5.73.0",
-    "webpack-cli": "^4.9.2"
+    "webpack-cli": "^4.10.0"
   },
   "browser": {
     "crypto": false
@@ -85,9 +89,9 @@
     "test": "npm run test:all",
     "test:all": "echo 'All Test - ESLint and JEST' && npm run test:lint && npm run test:jest",
     "test:lint": "echo 'Run ESlint(NOTE: maybe install eslint in global)' && eslint app.js webpack.config.js bin/www routes/*.js routes/*/*.js src/*/*.js src/*.jsx src/*/*.jsx test/*/*.js test/*/*.jsx && echo 'ESlint - Success' && echo ''",
-    "test:jest": "echo 'Run JEST' && jest && echo 'JEST - Success' && echo ''",
-    "test:update": "echo 'Update JEST snapshot' && jest --updateSnapshot && echo 'Update JEST snapshot - Success' && echo ''",
-    "test:watch": "echo 'Start JEST watch' && jest --watch && echo 'Start JEST watch - Success' && echo ''",
+    "test:jest": "echo 'Run JEST' && jest --env=jsdom && echo 'JEST - Success' && echo ''",
+    "test:update": "echo 'Update JEST snapshot' && jest --env=jsdom --updateSnapshot && echo 'Update JEST snapshot - Success' && echo ''",
+    "test:watch": "echo 'Start JEST watch' && jest --env=jsdom --watch && echo 'Start JEST watch - Success' && echo ''",
     "publish-please": "publish-please",
     "prepublishOnly": "publish-please guard",
     "deploy": "echo 'Deploy github pages for demo' && demo/demo_deploy.sh && echo 'Deploy github pages for demo - Success' && echo ''"

--- a/src/components/r3aboutdialog.jsx
+++ b/src/components/r3aboutdialog.jsx
@@ -23,15 +23,16 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';						// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-import { withTheme, withStyles }	from '@material-ui/core/styles';		// decorator
-import Button						from '@material-ui/core/Button';
-import Dialog						from '@material-ui/core/Dialog';
-import DialogTitle					from '@material-ui/core/DialogTitle';
-import DialogContent				from '@material-ui/core/DialogContent';
-import DialogContentText			from '@material-ui/core/DialogContentText';
-import DialogActions				from '@material-ui/core/DialogActions';
-import Typography					from '@material-ui/core/Typography';
-import CancelIcon					from '@material-ui/icons/Cancel';
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import Button						from '@mui/material/Button';
+import Dialog						from '@mui/material/Dialog';
+import DialogTitle					from '@mui/material/DialogTitle';
+import DialogContent				from '@mui/material/DialogContent';
+import DialogContentText			from '@mui/material/DialogContentText';
+import DialogActions				from '@mui/material/DialogActions';
+import Typography					from '@mui/material/Typography';
+import CancelIcon					from '@mui/icons-material/Cancel';
 
 import { r3IsEmptyString }			from '../util/r3util';
 import { r3AboutDialogStyles }		from './r3styles';

--- a/src/components/r3accountdialog.jsx
+++ b/src/components/r3accountdialog.jsx
@@ -23,17 +23,18 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';						// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-import { withTheme, withStyles }	from '@material-ui/core/styles';		// decorator
-import Button						from '@material-ui/core/Button';
-import Dialog						from '@material-ui/core/Dialog';
-import DialogTitle					from '@material-ui/core/DialogTitle';
-import DialogContent				from '@material-ui/core/DialogContent';
-import DialogActions				from '@material-ui/core/DialogActions';
-import Typography					from '@material-ui/core/Typography';
-import Tooltip						from '@material-ui/core/Tooltip';
-import TextField					from '@material-ui/core/TextField';
-import CheckCircleIcon				from '@material-ui/icons/CheckCircle';
-import CopyClipBoardIcon			from '@material-ui/icons/AssignmentTurnedInRounded';
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import Button						from '@mui/material/Button';
+import Dialog						from '@mui/material/Dialog';
+import DialogTitle					from '@mui/material/DialogTitle';
+import DialogContent				from '@mui/material/DialogContent';
+import DialogActions				from '@mui/material/DialogActions';
+import Typography					from '@mui/material/Typography';
+import Tooltip						from '@mui/material/Tooltip';
+import TextField					from '@mui/material/TextField';
+import CheckCircleIcon				from '@mui/icons-material/CheckCircle';
+import CopyClipBoardIcon			from '@mui/icons-material/AssignmentTurnedInRounded';
 
 import { r3AccountDialog }			from './r3styles';
 import { r3IsEmptyString, r3IsEmptyEntityObject, r3IsSafeTypedEntity } from '../util/r3util';
@@ -204,7 +205,7 @@ export default class R3AccountDialog extends React.Component
 						open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.copyClipboardButtonTooltip, 'boolean')) ? false : this.state.tooltips.copyClipboardButtonTooltip) }
 					>
 						<Button
-							onClick={ this.handleCopyClipboard  }
+							onClick={ this.handleCopyClipboard }
 							onMouseEnter={ event => this.handleCopyClipboardButtonTooltipChange(event, true) }
 							onMouseLeave={ event => this.handleCopyClipboardButtonTooltipChange(event, false) }
 							{ ...theme.r3AccountDialog.copyClipboardButton }

--- a/src/components/r3appbar.jsx
+++ b/src/components/r3appbar.jsx
@@ -23,20 +23,20 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';						// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-// For AppBar
-import { withTheme, withStyles }	from '@material-ui/core/styles';		// decorator
-import AppBar						from '@material-ui/core/AppBar';
-import Toolbar						from '@material-ui/core/Toolbar';
-import Typography					from '@material-ui/core/Typography';
-import Menu							from '@material-ui/core/Menu';
-import MenuItem						from '@material-ui/core/MenuItem';
-import IconButton					from '@material-ui/core/IconButton';
-import ListItemIcon					from '@material-ui/core/ListItemIcon';
-import Divider						from '@material-ui/core/Divider';
-import Tooltip						from '@material-ui/core/Tooltip';
-import MenuIcon						from '@material-ui/icons/Menu';
-import AccountCircleIcon			from '@material-ui/icons/AccountCircle';
-import ArrowRightIcon				from '@material-ui/icons/ArrowRight';
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import AppBar						from '@mui/material/AppBar';
+import Toolbar						from '@mui/material/Toolbar';
+import Typography					from '@mui/material/Typography';
+import Menu							from '@mui/material/Menu';
+import MenuItem						from '@mui/material/MenuItem';
+import IconButton					from '@mui/material/IconButton';
+import ListItemIcon					from '@mui/material/ListItemIcon';
+import Divider						from '@mui/material/Divider';
+import Tooltip						from '@mui/material/Tooltip';
+import MenuIcon						from '@mui/icons-material/Menu';
+import AccountCircleIcon			from '@mui/icons-material/AccountCircle';
+import ArrowRightIcon				from '@mui/icons-material/ArrowRight';
 
 import { r3AppBar }					from './r3styles';
 import R3PopupMsgDialog				from './r3popupmsgdialog';
@@ -333,6 +333,7 @@ export default class R3AppBar extends React.Component
 						onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.accountMenu, false) }
 						{ ...accountButton }
 						className={ accountButtonIcon }
+						size="large"
 					>
 						<AccountCircleIcon />
 					</IconButton>
@@ -342,7 +343,6 @@ export default class R3AppBar extends React.Component
 					anchorEl={ this.state.signMenuAnchorEl }
 					open={ Boolean(this.state.signMenuAnchorEl) }
 					onClose={ this.handleSignMenuClose }
-					getContentAnchorEl={ null }
 					{ ...theme.r3AppBar.accountMenu }
 				>
 					{ userMenuItem }
@@ -441,7 +441,6 @@ export default class R3AppBar extends React.Component
 					anchorEl={ this.state.licenseMenuAnchorEl }
 					open={ Boolean(this.state.licenseMenuAnchorEl) }
 					onClose={ this.handleMainMenuClose }
-					getContentAnchorEl={ null }
 					{ ...theme.r3AppBar.licenseMenu }
 				>
 					{ this.getLicensesMenuItems() }
@@ -479,6 +478,7 @@ export default class R3AppBar extends React.Component
 							onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.mainMenu, false) }
 							aria-owns={ this.state.mainMenuAnchorEl ? mainMenuId : undefined }
 							{ ...theme.r3AppBar.mainMenuButton }
+							size="large"
 						>
 							<MenuIcon />
 						</IconButton>
@@ -488,7 +488,6 @@ export default class R3AppBar extends React.Component
 						anchorEl={ this.state.mainMenuAnchorEl }
 						open={ Boolean(this.state.mainMenuAnchorEl) }
 						onClose={ this.handleMainMenuClose }
-						getContentAnchorEl={ null }
 						{ ...theme.r3AppBar.mainMenu }
 					>
 						{ this.getMainMenuItems() }
@@ -507,6 +506,7 @@ export default class R3AppBar extends React.Component
 							onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.mainMenu, true) }
 							onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.mainMenu, false) }
 							{ ...theme.r3AppBar.mainMenuButton }
+							size="large"
 						>
 							<MenuIcon />
 						</IconButton>
@@ -529,7 +529,7 @@ export default class R3AppBar extends React.Component
 
 	render()
 	{
-		const { theme, classes  } = this.props;
+		const { theme, classes } = this.props;
 
 		let	themeToolbar = (this.props.enDock ? theme.r3AppBar.toolbar : theme.r3AppBar.smallToolbar);
 

--- a/src/components/r3container.jsx
+++ b/src/components/r3container.jsx
@@ -23,8 +23,9 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';									// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-import { withTheme, withStyles }	from '@material-ui/core/styles';					// decorator
-import Paper						from '@material-ui/core/Paper';						// For contents wrap
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import Paper						from '@mui/material/Paper';							// For contents wrap
 
 // Styles
 import { r3Container }				from './r3styles';									// But nothing for r3Container now.

--- a/src/components/r3createpathdialog.jsx
+++ b/src/components/r3createpathdialog.jsx
@@ -23,16 +23,17 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';						// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-import { withTheme, withStyles }	from '@material-ui/core/styles';		// decorator
-import TextField					from '@material-ui/core/TextField';
-import Button						from '@material-ui/core/Button';
-import Dialog						from '@material-ui/core/Dialog';
-import DialogTitle					from '@material-ui/core/DialogTitle';
-import DialogContent				from '@material-ui/core/DialogContent';
-import DialogActions				from '@material-ui/core/DialogActions';
-import Typography					from '@material-ui/core/Typography';
-import CheckCircleIcon				from '@material-ui/icons/CheckCircle';
-import CancelIcon					from '@material-ui/icons/Cancel';
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import TextField					from '@mui/material/TextField';
+import Button						from '@mui/material/Button';
+import Dialog						from '@mui/material/Dialog';
+import DialogTitle					from '@mui/material/DialogTitle';
+import DialogContent				from '@mui/material/DialogContent';
+import DialogActions				from '@mui/material/DialogActions';
+import Typography					from '@mui/material/Typography';
+import CheckCircleIcon				from '@mui/icons-material/CheckCircle';
+import CancelIcon					from '@mui/icons-material/Cancel';
 
 import { r3CreatePathDialog }		from './r3styles';
 import { r3IsEmptyStringObject, r3IsEmptyString } from '../util/r3util';

--- a/src/components/r3createservicedialog.jsx
+++ b/src/components/r3createservicedialog.jsx
@@ -23,32 +23,33 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';						// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-import { withTheme, withStyles }	from '@material-ui/core/styles';		// decorator
-import TextField					from '@material-ui/core/TextField';
-import Button						from '@material-ui/core/Button';
-import Dialog						from '@material-ui/core/Dialog';
-import DialogTitle					from '@material-ui/core/DialogTitle';
-import DialogContent				from '@material-ui/core/DialogContent';
-import DialogActions				from '@material-ui/core/DialogActions';
-import Typography					from '@material-ui/core/Typography';
-import Box							from '@material-ui/core/Box';
-import FormControlLabel				from '@material-ui/core/FormControlLabel';
-import RadioGroup					from '@material-ui/core/RadioGroup';
-import Radio						from '@material-ui/core/Radio';
-import Table						from '@material-ui/core/Table';
-import TableBody					from '@material-ui/core/TableBody';
-import TableCell					from '@material-ui/core/TableCell';
-import TableHead					from '@material-ui/core/TableHead';
-import TablePagination				from '@material-ui/core/TablePagination';
-import TableRow						from '@material-ui/core/TableRow';
-import Tooltip						from '@material-ui/core/Tooltip';
-import Popover						from '@material-ui/core/Popover';
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import TextField					from '@mui/material/TextField';
+import Button						from '@mui/material/Button';
+import Dialog						from '@mui/material/Dialog';
+import DialogTitle					from '@mui/material/DialogTitle';
+import DialogContent				from '@mui/material/DialogContent';
+import DialogActions				from '@mui/material/DialogActions';
+import Typography					from '@mui/material/Typography';
+import Box							from '@mui/material/Box';
+import FormControlLabel				from '@mui/material/FormControlLabel';
+import RadioGroup					from '@mui/material/RadioGroup';
+import Radio						from '@mui/material/Radio';
+import Table						from '@mui/material/Table';
+import TableBody					from '@mui/material/TableBody';
+import TableCell					from '@mui/material/TableCell';
+import TableHead					from '@mui/material/TableHead';
+import TablePagination				from '@mui/material/TablePagination';
+import TableRow						from '@mui/material/TableRow';
+import Tooltip						from '@mui/material/Tooltip';
+import Popover						from '@mui/material/Popover';
 
-import AddIcon						from '@material-ui/icons/AddBoxRounded';
-import DeleteIcon					from '@material-ui/icons/Delete';
-import EditIcon						from '@material-ui/icons/Edit';
-import CheckCircleIcon				from '@material-ui/icons/CheckCircle';
-import CancelIcon					from '@material-ui/icons/Cancel';
+import AddIcon						from '@mui/icons-material/AddBoxRounded';
+import DeleteIcon					from '@mui/icons-material/Delete';
+import EditIcon						from '@mui/icons-material/Edit';
+import CheckCircleIcon				from '@mui/icons-material/CheckCircle';
+import CancelIcon					from '@mui/icons-material/Cancel';
 
 import { r3CreateServiceDialog }	from './r3styles';
 import { serviceResTypeUrl, serviceResTypeObject }	from '../util/r3types';
@@ -1198,7 +1199,7 @@ export default class R3CreateServiceDialog extends React.Component
 						rowsPerPage={ this.props.tableKeysRawCount }
 						page={ this.state.staticResKeysPageNum }
 						rowsPerPageOptions={ [] }
-						onChangePage={ this.handleStaticResKeysPageChange }
+						onPageChange={ this.handleStaticResKeysPageChange }
 					/>
 				</Box>
 			</React.Fragment>
@@ -1637,7 +1638,7 @@ export default class R3CreateServiceDialog extends React.Component
 					rowsPerPage={ this.props.tableRawCount }
 					page={ this.state.staticResPageNum }
 					rowsPerPageOptions={ [] }
-					onChangePage={ this.handleResStaticObjPageChange }
+					onPageChange={ this.handleResStaticObjPageChange }
 				/>
 				<TextField
 					id={ dialogComponentsIds.staticObjTextFieldId }

--- a/src/components/r3createservicetenantdialog.jsx
+++ b/src/components/r3createservicetenantdialog.jsx
@@ -23,16 +23,17 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';						// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-import { withTheme, withStyles }	from '@material-ui/core/styles';		// decorator
-import TextField					from '@material-ui/core/TextField';
-import Button						from '@material-ui/core/Button';
-import Dialog						from '@material-ui/core/Dialog';
-import DialogTitle					from '@material-ui/core/DialogTitle';
-import DialogContent				from '@material-ui/core/DialogContent';
-import DialogActions				from '@material-ui/core/DialogActions';
-import Typography					from '@material-ui/core/Typography';
-import CheckCircleIcon				from '@material-ui/icons/CheckCircle';
-import CancelIcon					from '@material-ui/icons/Cancel';
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import TextField					from '@mui/material/TextField';
+import Button						from '@mui/material/Button';
+import Dialog						from '@mui/material/Dialog';
+import DialogTitle					from '@mui/material/DialogTitle';
+import DialogContent				from '@mui/material/DialogContent';
+import DialogActions				from '@mui/material/DialogActions';
+import Typography					from '@mui/material/Typography';
+import CheckCircleIcon				from '@mui/icons-material/CheckCircle';
+import CancelIcon					from '@mui/icons-material/Cancel';
 
 import { r3CreateServiceTenantDialog } from './r3styles';
 import { r3IsEmptyStringObject, r3IsEmptyString } from '../util/r3util';

--- a/src/components/r3formbuttons.jsx
+++ b/src/components/r3formbuttons.jsx
@@ -23,10 +23,11 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';						// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-import { withTheme, withStyles }	from '@material-ui/core/styles';		// decorator
-import Button						from '@material-ui/core/Button';
-import CheckCircleIcon				from '@material-ui/icons/CheckCircle';
-import CancelIcon					from '@material-ui/icons/Cancel';
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import Button						from '@mui/material/Button';
+import CheckCircleIcon				from '@mui/icons-material/CheckCircle';
+import CancelIcon					from '@mui/icons-material/Cancel';
 
 import { r3FormButtons }			from './r3styles';
 

--- a/src/components/r3maintree.jsx
+++ b/src/components/r3maintree.jsx
@@ -23,30 +23,30 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';						// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-// For MainTree
-import { withTheme, withStyles }	from '@material-ui/core/styles';		// decorator
-import AppBar						from '@material-ui/core/AppBar';
-import Toolbar						from '@material-ui/core/Toolbar';
-import Drawer						from '@material-ui/core/Drawer';
-import Chip							from '@material-ui/core/Chip';
-import Menu							from '@material-ui/core/Menu';
-import MenuItem						from '@material-ui/core/MenuItem';
-import IconButton					from '@material-ui/core/IconButton';
-import Tooltip						from '@material-ui/core/Tooltip';
-import Typography					from '@material-ui/core/Typography';
-import List							from '@material-ui/core/List';
-import ListItem						from '@material-ui/core/ListItem';
-import ListItemText					from '@material-ui/core/ListItemText';
-import ListItemIcon					from '@material-ui/core/ListItemIcon';
-import Collapse						from '@material-ui/core/Collapse';
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import AppBar						from '@mui/material/AppBar';
+import Toolbar						from '@mui/material/Toolbar';
+import Drawer						from '@mui/material/Drawer';
+import Chip							from '@mui/material/Chip';
+import Menu							from '@mui/material/Menu';
+import MenuItem						from '@mui/material/MenuItem';
+import IconButton					from '@mui/material/IconButton';
+import Tooltip						from '@mui/material/Tooltip';
+import Typography					from '@mui/material/Typography';
+import List							from '@mui/material/List';
+import ListItem						from '@mui/material/ListItem';
+import ListItemText					from '@mui/material/ListItemText';
+import ListItemIcon					from '@mui/material/ListItemIcon';
+import Collapse						from '@mui/material/Collapse';
 
-import ExpandLessIcon				from '@material-ui/icons/ExpandLess';
-import ExpandMoreIcon				from '@material-ui/icons/ExpandMore';
-import MenuIcon						from '@material-ui/icons/Menu';
-import ArrowRightIcon				from '@material-ui/icons/ArrowRight';
-import LabelIcon					from '@material-ui/icons/Label';
-import OwnerIcon					from '@material-ui/icons/Person';
-import MoreVertIcon					from '@material-ui/icons/MoreVert';
+import ExpandLessIcon				from '@mui/icons-material/ExpandLess';
+import ExpandMoreIcon				from '@mui/icons-material/ExpandMore';
+import MenuIcon						from '@mui/icons-material/Menu';
+import ArrowRightIcon				from '@mui/icons-material/ArrowRight';
+import LabelIcon					from '@mui/icons-material/Label';
+import OwnerIcon					from '@mui/icons-material/Person';
+import MoreVertIcon					from '@mui/icons-material/MoreVert';
 
 import { r3MainTree }				from './r3styles';
 import R3PopupMsgDialog				from './r3popupmsgdialog';
@@ -487,7 +487,6 @@ export default class R3MainTree extends React.Component
 					anchorEl={ this.state.dummyLicenseMenuAnchorEl }
 					open={ Boolean(this.state.dummyLicenseMenuAnchorEl) }
 					onClose={ this.handleDummyBarMenuClose }
-					getContentAnchorEl={ null }
 					{ ...theme.r3MainTree.licenseMenu }
 				>
 					{ this.getLicensesMenuItems() }
@@ -562,6 +561,7 @@ export default class R3MainTree extends React.Component
 							onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.mainMenu, false) }
 							aria-owns={ this.state.dummyBarMenuAnchorEl ? componentKeyIds.dummyBarMenuId : undefined }
 							{ ...theme.r3MainTree.dummyBarMainMenuButton }
+							size="large"
 						>
 							<MenuIcon />
 						</IconButton>
@@ -572,7 +572,6 @@ export default class R3MainTree extends React.Component
 						anchorEl={ this.state.dummyBarMenuAnchorEl }
 						open={ Boolean(this.state.dummyBarMenuAnchorEl) }
 						onClose={ this.handleDummyBarMenuClose }
-						getContentAnchorEl={ null }
 						{ ...theme.r3MainTree.dummyBarMainMenu }
 					>
 						{ this.getMenuItems() }
@@ -643,6 +642,7 @@ export default class R3MainTree extends React.Component
 							onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.tenantMenu, true) }
 							onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.tenantMenu, false) }
 							{ ...theme.r3MainTree.tenantListButton }
+							size="large"
 						>
 							<MoreVertIcon />
 						</IconButton>
@@ -653,7 +653,6 @@ export default class R3MainTree extends React.Component
 						anchorEl={ this.state.tenantMenuAnchorEl }
 						open={ Boolean(this.state.tenantMenuAnchorEl) }
 						onClose={ this.handleTenantMenuClose }
-						getContentAnchorEl={ null }
 						{ ...theme.r3MainTree.tenantListMenu }
 					>
 						{ menuItem }

--- a/src/components/r3msgbox.jsx
+++ b/src/components/r3msgbox.jsx
@@ -23,13 +23,13 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';						// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-// Components
-import { withTheme, withStyles }	from '@material-ui/core/styles';		// decorator
-import Paper						from '@material-ui/core/Paper';			// For contents wrap
-import Typography					from '@material-ui/core/Typography';
-import ErrorIcon					from '@material-ui/icons/ErrorRounded';
-import WarningIcon					from '@material-ui/icons/WarningRounded';
-import InformationIcon				from '@material-ui/icons/InfoOutlined';
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import Paper						from '@mui/material/Paper';				// For contents wrap
+import Typography					from '@mui/material/Typography';
+import ErrorIcon					from '@mui/icons-material/ErrorRounded';
+import WarningIcon					from '@mui/icons-material/WarningRounded';
+import InformationIcon				from '@mui/icons-material/InfoOutlined';
 
 import { r3MsgBox }					from './r3styles';
 import R3Message					from '../util/r3message';

--- a/src/components/r3pathinfodialog.jsx
+++ b/src/components/r3pathinfodialog.jsx
@@ -23,34 +23,35 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';						// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-import { withTheme, withStyles }	from '@material-ui/core/styles';		// decorator
-import Button						from '@material-ui/core/Button';
-import Dialog						from '@material-ui/core/Dialog';
-import DialogTitle					from '@material-ui/core/DialogTitle';
-import DialogContent				from '@material-ui/core/DialogContent';
-import DialogActions				from '@material-ui/core/DialogActions';
-import Typography					from '@material-ui/core/Typography';
-import TextField					from '@material-ui/core/TextField';
-import Tooltip						from '@material-ui/core/Tooltip';
-import Table						from '@material-ui/core/Table';
-import TableBody					from '@material-ui/core/TableBody';
-import TableCell					from '@material-ui/core/TableCell';
-import TableHead					from '@material-ui/core/TableHead';
-import TablePagination				from '@material-ui/core/TablePagination';
-import TableRow						from '@material-ui/core/TableRow';
-import Popover						from '@material-ui/core/Popover';
-import FormControlLabel				from '@material-ui/core/FormControlLabel';
-import Checkbox						from '@material-ui/core/Checkbox';
-import Select						from '@material-ui/core/Select';
-import MenuItem						from '@material-ui/core/MenuItem';		// for select
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import Button						from '@mui/material/Button';
+import Dialog						from '@mui/material/Dialog';
+import DialogTitle					from '@mui/material/DialogTitle';
+import DialogContent				from '@mui/material/DialogContent';
+import DialogActions				from '@mui/material/DialogActions';
+import Typography					from '@mui/material/Typography';
+import TextField					from '@mui/material/TextField';
+import Tooltip						from '@mui/material/Tooltip';
+import Table						from '@mui/material/Table';
+import TableBody					from '@mui/material/TableBody';
+import TableCell					from '@mui/material/TableCell';
+import TableHead					from '@mui/material/TableHead';
+import TablePagination				from '@mui/material/TablePagination';
+import TableRow						from '@mui/material/TableRow';
+import Popover						from '@mui/material/Popover';
+import FormControlLabel				from '@mui/material/FormControlLabel';
+import Checkbox						from '@mui/material/Checkbox';
+import Select						from '@mui/material/Select';
+import MenuItem						from '@mui/material/MenuItem';			// for select
 
-import CheckCircleIcon				from '@material-ui/icons/CheckCircle';
-import CopyClipBoardIcon			from '@material-ui/icons/AssignmentTurnedInRounded';
-import SettingActionIcon			from '@material-ui/icons/SettingsApplicationsRounded';
-import CreateRoleTokenIcon			from '@material-ui/icons/AddBoxRounded';
-import DeleteIcon					from '@material-ui/icons/Delete';
-import DispCodeIcon					from '@material-ui/icons/ViewListRounded';
-import BackPageIcon					from '@material-ui/icons/Cancel';
+import CheckCircleIcon				from '@mui/icons-material/CheckCircle';
+import CopyClipBoardIcon			from '@mui/icons-material/AssignmentTurnedInRounded';
+import SettingActionIcon			from '@mui/icons-material/SettingsApplicationsRounded';
+import CreateRoleTokenIcon			from '@mui/icons-material/AddBoxRounded';
+import DeleteIcon					from '@mui/icons-material/Delete';
+import DispCodeIcon					from '@mui/icons-material/ViewListRounded';
+import BackPageIcon					from '@mui/icons-material/Cancel';
 
 import R3MsgBox						from './r3msgbox';						// Message Box
 import R3Message					from '../util/r3message';
@@ -1309,7 +1310,7 @@ export default class R3PathInfoDialog extends React.Component
 					open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.roletokenClipboardButtonTooltip, 'boolean')) ? false : this.state.tooltips.roletokenClipboardButtonTooltip) }
 				>
 					<Button
-						onClick={ this.handleRoleTokenClipboard  }
+						onClick={ this.handleRoleTokenClipboard }
 						onMouseEnter={ event => this.handleRoleTokenClipboardButtonTooltipChange(event, true) }
 						onMouseLeave={ event => this.handleRoleTokenClipboardButtonTooltipChange(event, false) }
 						{ ...theme.r3PathInfoDialog.roletokenClipboardButton }
@@ -1420,7 +1421,7 @@ export default class R3PathInfoDialog extends React.Component
 					open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.copyClipboardButtonTooltip, 'boolean')) ? false : this.state.tooltips.copyClipboardButtonTooltip) }
 				>
 					<Button
-						onClick={ this.handleCopyClipboard  }
+						onClick={ this.handleCopyClipboard }
 						onMouseEnter={ event => this.handleCopyClipboardButtonTooltipChange(event, true) }
 						onMouseLeave={ event => this.handleCopyClipboardButtonTooltipChange(event, false) }
 						{ ...theme.r3PathInfoDialog.copyClipboardButton }

--- a/src/components/r3policy.jsx
+++ b/src/components/r3policy.jsx
@@ -23,20 +23,21 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';						// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-import { withTheme, withStyles }	from '@material-ui/core/styles';		// decorator
-import TextField					from '@material-ui/core/TextField';
-import Typography					from '@material-ui/core/Typography';
-import IconButton					from '@material-ui/core/IconButton';
-import Select						from '@material-ui/core/Select';
-import MenuItem						from '@material-ui/core/MenuItem';
-import FormGroup					from '@material-ui/core/FormGroup';		// For Checkbox
-import FormControlLabel				from '@material-ui/core/FormControlLabel';
-import Checkbox						from '@material-ui/core/Checkbox';
-import Tooltip						from '@material-ui/core/Tooltip';
-import DeleteIcon					from '@material-ui/icons/ClearRounded';
-import AddIcon						from '@material-ui/icons/AddRounded';
-import UpIcon						from '@material-ui/icons/ArrowUpwardRounded';
-import DownIcon						from '@material-ui/icons/ArrowDownwardRounded';
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import TextField					from '@mui/material/TextField';
+import Typography					from '@mui/material/Typography';
+import IconButton					from '@mui/material/IconButton';
+import Select						from '@mui/material/Select';
+import MenuItem						from '@mui/material/MenuItem';
+import FormGroup					from '@mui/material/FormGroup';		// For Checkbox
+import FormControlLabel				from '@mui/material/FormControlLabel';
+import Checkbox						from '@mui/material/Checkbox';
+import Tooltip						from '@mui/material/Tooltip';
+import DeleteIcon					from '@mui/icons-material/ClearRounded';
+import AddIcon						from '@mui/icons-material/AddRounded';
+import UpIcon						from '@mui/icons-material/ArrowUpwardRounded';
+import DownIcon						from '@mui/icons-material/ArrowDownwardRounded';
 
 import { r3Policy }					from './r3styles';
 import R3FormButtons				from './r3formbuttons';					// Buttons
@@ -764,68 +765,68 @@ export default class R3Policy extends React.Component
 		}
 		let	_items = items;
 
-		return (
-			_items.map( (item, pos) =>
-			{
-				let	deleteButton;
-				if(this.props.isReadMode){
-					deleteButton = (
+		return _items.map( (item, pos) =>
+		{
+			let	deleteButton;
+			if(this.props.isReadMode){
+				deleteButton = (
+					<IconButton
+						disabled={ true }
+						{ ...theme.r3Policy.deleteResourceButton }
+						className={ classes.deleteInvisibleResourceButton }
+						size="large"
+					>
+						<DeleteIcon />
+					</IconButton>
+				);
+			}else{
+				deleteButton = (
+					<Tooltip
+						title={ r3provider.getR3TextRes().tResPolicyResourceDelTT }
+						open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.deleteResourceTooltip, 'number') || (this.state.tooltips.deleteResourceTooltip != pos)) ? false : true) }
+					>
 						<IconButton
-							disabled={ true }
+							onClick={ (event) => this.handleResourceChange(event, actionTypeDelete, pos) }
+							onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.deleteResourceTooltip, pos) }
+							onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.deleteResourceTooltip, -1) }
 							{ ...theme.r3Policy.deleteResourceButton }
-							className={ classes.deleteInvisibleResourceButton }
+							className={ classes.deleteResourceButton }
+							size="large"
 						>
 							<DeleteIcon />
 						</IconButton>
-					);
-				}else{
-					deleteButton = (
-						<Tooltip
-							title={ r3provider.getR3TextRes().tResPolicyResourceDelTT }
-							open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.deleteResourceTooltip, 'number') || (this.state.tooltips.deleteResourceTooltip != pos)) ? false : true) }
-						>
-							<IconButton
-								onClick={ (event) => this.handleResourceChange(event, actionTypeDelete, pos) }
-								onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.deleteResourceTooltip, pos) }
-								onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.deleteResourceTooltip, -1) }
-								{ ...theme.r3Policy.deleteResourceButton }
-								className={ classes.deleteResourceButton }
-							>
-								<DeleteIcon />
-							</IconButton>
-						</Tooltip>
-					);
-				}
-
-				let	inputProps;
-				if(this.props.isReadMode){
-					inputProps = {};
-				}else{
-					inputProps = {
-						className: classes.inputTextField
-					};
-				}
-
-				return (
-					<div
-						key={ pos }
-						className={ classes.enclosureElement }
-					>
-						<TextField
-							name={ policyComponentValues.resourceTextFieldNamePrefix + String(pos) }
-							disabled={ this.props.isReadMode }
-							value={ item }
-							placeholder={ r3provider.getR3TextRes().tResPolicyResourceHint }
-							onChange={ (event) => this.handleResourceChange(event, actionTypeValue, pos) }
-							InputProps={ inputProps }
-							{ ...theme.r3Policy.resourceTextField }
-							className={ classes.resourceTextField }
-						/>
-						{ deleteButton }
-					</div>
+					</Tooltip>
 				);
-			})
-		);
+			}
+
+			let	inputProps;
+			if(this.props.isReadMode){
+				inputProps = {};
+			}else{
+				inputProps = {
+					className: classes.inputTextField
+				};
+			}
+
+			return (
+				<div
+					key={ pos }
+					className={ classes.enclosureElement }
+				>
+					<TextField
+						name={ policyComponentValues.resourceTextFieldNamePrefix + String(pos) }
+						disabled={ this.props.isReadMode }
+						value={ item }
+						placeholder={ r3provider.getR3TextRes().tResPolicyResourceHint }
+						onChange={ (event) => this.handleResourceChange(event, actionTypeValue, pos) }
+						InputProps={ inputProps }
+						{ ...theme.r3Policy.resourceTextField }
+						className={ classes.resourceTextField }
+					/>
+					{ deleteButton }
+				</div>
+			);
+		});
 	}
 
 	getAddResourceContents()
@@ -859,6 +860,7 @@ export default class R3Policy extends React.Component
 						onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.addResourceTooltip, false) }
 						{ ...theme.r3Policy.addResourceButton }
 						className={ classes.addResourceButton }
+						size="large"
 					>
 						<AddIcon />
 					</IconButton>
@@ -876,130 +878,134 @@ export default class R3Policy extends React.Component
 		}
 		let	_items = items;
 
-		return (
-			_items.map( (item, pos) =>
-			{
-				let	downButton;
-				if(this.props.isReadMode || (_items.length <= (pos + 1))){
-					downButton = (
+		return _items.map( (item, pos) =>
+		{
+			let	downButton;
+			if(this.props.isReadMode || (_items.length <= (pos + 1))){
+				downButton = (
+					<IconButton
+						disabled={ true }
+						{ ...theme.r3Policy.downAliasButton }
+						className={ classes.arrowInvisibleAliasButton }
+						size="large"
+					>
+						<DownIcon />
+					</IconButton>
+				);
+			}else{
+				downButton = (
+					<Tooltip
+						title={ r3provider.getR3TextRes().tResAliasDownTT }
+						open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.downAliasTooltip, 'number') || (this.state.tooltips.downAliasTooltip != pos)) ? false : true) }
+					>
 						<IconButton
-							disabled={ true }
+							onClick={ (event) => this.handleAliasesChange(event, actionTypeDown, pos) }
+							onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.downAliasTooltip, pos) }
+							onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.downAliasTooltip, -1) }
 							{ ...theme.r3Policy.downAliasButton }
-							className={ classes.arrowInvisibleAliasButton }
+							className={ classes.arrowAliasButton }
+							size="large"
 						>
 							<DownIcon />
 						</IconButton>
-					);
-				}else{
-					downButton = (
-						<Tooltip
-							title={ r3provider.getR3TextRes().tResAliasDownTT }
-							open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.downAliasTooltip, 'number') || (this.state.tooltips.downAliasTooltip != pos)) ? false : true) }
-						>
-							<IconButton
-								onClick={ (event) => this.handleAliasesChange(event, actionTypeDown, pos) }
-								onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.downAliasTooltip, pos) }
-								onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.downAliasTooltip, -1) }
-								{ ...theme.r3Policy.downAliasButton }
-								className={ classes.arrowAliasButton }
-							>
-								<DownIcon />
-							</IconButton>
-						</Tooltip>
-					);
-				}
+					</Tooltip>
+				);
+			}
 
-				let	upButton;
-				if(this.props.isReadMode || (0 === pos)){
-					upButton = (
+			let	upButton;
+			if(this.props.isReadMode || (0 === pos)){
+				upButton = (
+					<IconButton
+						disabled={ true }
+						{ ...theme.r3Policy.upAliasButton }
+						className={ classes.arrowInvisibleAliasButton }
+						size="large"
+					>
+						<UpIcon />
+					</IconButton>
+				);
+			}else{
+				upButton = (
+					<Tooltip
+						title={ r3provider.getR3TextRes().tResAliasUpTT }
+						open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.upAliasTooltip, 'number') || (this.state.tooltips.upAliasTooltip != pos)) ? false : true) }
+					>
 						<IconButton
-							disabled={ true }
+							onClick={ (event) => this.handleAliasesChange(event, actionTypeUp, pos) }
+							onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.upAliasTooltip, pos) }
+							onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.upAliasTooltip, -1) }
 							{ ...theme.r3Policy.upAliasButton }
-							className={ classes.arrowInvisibleAliasButton }
+							className={ classes.arrowAliasButton }
+							size="large"
 						>
 							<UpIcon />
 						</IconButton>
-					);
-				}else{
-					upButton = (
-						<Tooltip
-							title={ r3provider.getR3TextRes().tResAliasUpTT }
-							open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.upAliasTooltip, 'number') || (this.state.tooltips.upAliasTooltip != pos)) ? false : true) }
-						>
-							<IconButton
-								onClick={ (event) => this.handleAliasesChange(event, actionTypeUp, pos) }
-								onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.upAliasTooltip, pos) }
-								onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.upAliasTooltip, -1) }
-								{ ...theme.r3Policy.upAliasButton }
-								className={ classes.arrowAliasButton }
-							>
-								<UpIcon />
-							</IconButton>
-						</Tooltip>
-					);
-				}
+					</Tooltip>
+				);
+			}
 
-				let	deleteButton;
-				if(this.props.isReadMode){
-					deleteButton = (
+			let	deleteButton;
+			if(this.props.isReadMode){
+				deleteButton = (
+					<IconButton
+						disabled={ true }
+						{ ...theme.r3Policy.deleteAliasButton }
+						className={ classes.deleteInvisibleAliasButton }
+						size="large"
+					>
+						<DeleteIcon />
+					</IconButton>
+				);
+			}else{
+				deleteButton = (
+					<Tooltip
+						title={ r3provider.getR3TextRes().tResAliasDelTT }
+						open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.deleteAliasTooltip, 'number') || (this.state.tooltips.deleteAliasTooltip != pos)) ? false : true) }
+					>
 						<IconButton
-							disabled={ true }
+							onClick={ (event) => this.handleAliasesChange(event, actionTypeDelete, pos) }
+							onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.deleteAliasTooltip, pos) }
+							onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.deleteAliasTooltip, -1) }
 							{ ...theme.r3Policy.deleteAliasButton }
-							className={ classes.deleteInvisibleAliasButton }
+							className={ classes.deleteAliasButton }
+							size="large"
 						>
 							<DeleteIcon />
 						</IconButton>
-					);
-				}else{
-					deleteButton = (
-						<Tooltip
-							title={ r3provider.getR3TextRes().tResAliasDelTT }
-							open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.deleteAliasTooltip, 'number') || (this.state.tooltips.deleteAliasTooltip != pos)) ? false : true) }
-						>
-							<IconButton
-								onClick={ (event) => this.handleAliasesChange(event, actionTypeDelete, pos) }
-								onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.deleteAliasTooltip, pos) }
-								onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.deleteAliasTooltip, -1) }
-								{ ...theme.r3Policy.deleteAliasButton }
-								className={ classes.deleteAliasButton }
-							>
-								<DeleteIcon />
-							</IconButton>
-						</Tooltip>
-					);
-				}
-
-				let	inputProps;
-				if(this.props.isReadMode){
-					inputProps = {};
-				}else{
-					inputProps = {
-						className: classes.inputTextField
-					};
-				}
-
-				return (
-					<div
-						key={ pos }
-						className={ classes.enclosureElement }
-					>
-						<TextField
-							name={ policyComponentValues.aliasTextFieldNamePrefix + String(pos) }
-							disabled={ this.props.isReadMode }
-							value={ item }
-							placeholder={ r3provider.getR3TextRes().tResAliasHint }
-							onChange={ (event) => this.handleAliasesChange(event, actionTypeValue, pos) }
-							InputProps={ inputProps }
-							{ ...theme.r3Policy.aliasTextField }
-							className={ classes.aliasTextField }
-						/>
-						{ downButton }
-						{ upButton }
-						{ deleteButton }
-					</div>
+					</Tooltip>
 				);
-			})
-		);
+			}
+
+			let	inputProps;
+			if(this.props.isReadMode){
+				inputProps = {};
+			}else{
+				inputProps = {
+					className: classes.inputTextField
+				};
+			}
+
+			return (
+				<div
+					key={ pos }
+					className={ classes.enclosureElement }
+				>
+					<TextField
+						name={ policyComponentValues.aliasTextFieldNamePrefix + String(pos) }
+						disabled={ this.props.isReadMode }
+						value={ item }
+						placeholder={ r3provider.getR3TextRes().tResAliasHint }
+						onChange={ (event) => this.handleAliasesChange(event, actionTypeValue, pos) }
+						InputProps={ inputProps }
+						{ ...theme.r3Policy.aliasTextField }
+						className={ classes.aliasTextField }
+					/>
+					{ downButton }
+					{ upButton }
+					{ deleteButton }
+				</div>
+			);
+		});
 	}
 
 	getAddAliasContents()
@@ -1033,6 +1039,7 @@ export default class R3Policy extends React.Component
 						onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.addAliasTooltip, false) }
 						{ ...theme.r3Policy.addAliasButton }
 						className={ classes.addAliasButton }
+						size="large"
 					>
 						<AddIcon />
 					</IconButton>

--- a/src/components/r3popupmsgdialog.jsx
+++ b/src/components/r3popupmsgdialog.jsx
@@ -23,19 +23,20 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';						// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-import { withTheme, withStyles }	from '@material-ui/core/styles';		// decorator
-import Button						from '@material-ui/core/Button';
-import Dialog						from '@material-ui/core/Dialog';
-import DialogTitle					from '@material-ui/core/DialogTitle';
-import DialogContent				from '@material-ui/core/DialogContent';
-import DialogContentText			from '@material-ui/core/DialogContentText';
-import DialogActions				from '@material-ui/core/DialogActions';
-import Typography					from '@material-ui/core/Typography';
-import CheckCircleIcon				from '@material-ui/icons/CheckCircle';
-import CancelIcon					from '@material-ui/icons/Cancel';
-import ErrorIcon					from '@material-ui/icons/ErrorRounded';
-import WarningIcon					from '@material-ui/icons/WarningRounded';
-import InformationIcon				from '@material-ui/icons/InfoOutlined';
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import Button						from '@mui/material/Button';
+import Dialog						from '@mui/material/Dialog';
+import DialogTitle					from '@mui/material/DialogTitle';
+import DialogContent				from '@mui/material/DialogContent';
+import DialogContentText			from '@mui/material/DialogContentText';
+import DialogActions				from '@mui/material/DialogActions';
+import Typography					from '@mui/material/Typography';
+import CheckCircleIcon				from '@mui/icons-material/CheckCircle';
+import CancelIcon					from '@mui/icons-material/Cancel';
+import ErrorIcon					from '@mui/icons-material/ErrorRounded';
+import WarningIcon					from '@mui/icons-material/WarningRounded';
+import InformationIcon				from '@mui/icons-material/InfoOutlined';
 
 import { r3PopupMsgDialog }			from './r3styles';
 

--- a/src/components/r3progress.jsx
+++ b/src/components/r3progress.jsx
@@ -23,9 +23,10 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';						// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-import { withTheme, withStyles }	from '@material-ui/core/styles';		// decorator
-import Paper						from '@material-ui/core/Paper';
-import CircularProgress				from '@material-ui/core/CircularProgress';
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import Paper						from '@mui/material/Paper';
+import CircularProgress				from '@mui/material/CircularProgress';
 
 import { r3Progress }				from './r3styles';
 
@@ -84,7 +85,7 @@ export default class R3Progress extends React.Component
 
 	render()
 	{
-		const { theme, classes  } = this.props;
+		const { theme, classes } = this.props;
 
 		if(!this.state.open){
 			return null;

--- a/src/components/r3resource.jsx
+++ b/src/components/r3resource.jsx
@@ -23,19 +23,20 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';						// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-import { withTheme, withStyles }	from '@material-ui/core/styles';		// decorator
-import TextField					from '@material-ui/core/TextField';
-import Typography					from '@material-ui/core/Typography';
-import IconButton					from '@material-ui/core/IconButton';
-import FormControl					from '@material-ui/core/FormControl';	// For Radio Button
-import FormControlLabel				from '@material-ui/core/FormControlLabel';
-import RadioGroup					from '@material-ui/core/RadioGroup';
-import Radio						from '@material-ui/core/Radio';
-import Tooltip						from '@material-ui/core/Tooltip';
-import DeleteIcon					from '@material-ui/icons/ClearRounded';
-import AddIcon						from '@material-ui/icons/AddRounded';
-import UpIcon						from '@material-ui/icons/ArrowUpwardRounded';
-import DownIcon						from '@material-ui/icons/ArrowDownwardRounded';
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import TextField					from '@mui/material/TextField';
+import Typography					from '@mui/material/Typography';
+import IconButton					from '@mui/material/IconButton';
+import FormControl					from '@mui/material/FormControl';	// For Radio Button
+import FormControlLabel				from '@mui/material/FormControlLabel';
+import RadioGroup					from '@mui/material/RadioGroup';
+import Radio						from '@mui/material/Radio';
+import Tooltip						from '@mui/material/Tooltip';
+import DeleteIcon					from '@mui/icons-material/ClearRounded';
+import AddIcon						from '@mui/icons-material/AddRounded';
+import UpIcon						from '@mui/icons-material/ArrowUpwardRounded';
+import DownIcon						from '@mui/icons-material/ArrowDownwardRounded';
 
 import { r3Resource }				from './r3styles';
 import R3FormButtons				from './r3formbuttons';					// Buttons
@@ -768,6 +769,7 @@ export default class R3Resource extends React.Component
 						disabled={ true }
 						{ ...theme.r3Resource.deleteKeysButton }
 						className={ classes.deleteInvisibleKeysButton }
+						size="large"
 					>
 						<DeleteIcon />
 					</IconButton>
@@ -784,6 +786,7 @@ export default class R3Resource extends React.Component
 							onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.deleteKeysTooltip, null) }
 							{ ...theme.r3Resource.deleteKeysButton }
 							className={ classes.deleteKeysButton }
+							size="large"
 						>
 							<DeleteIcon />
 						</IconButton>
@@ -877,6 +880,7 @@ export default class R3Resource extends React.Component
 						onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.addKeysTooltip, false) }
 						{ ...theme.r3Resource.addKeysButton }
 						className={ classes.addKeysButton }
+						size="large"
 					>
 						<AddIcon />
 					</IconButton>
@@ -894,130 +898,134 @@ export default class R3Resource extends React.Component
 		}
 		let	_items = items;
 
-		return (
-			_items.map( (item, pos) =>
-			{
-				let	downButton;
-				if(this.props.isReadMode || (_items.length <= (pos + 1))){
-					downButton = (
+		return _items.map( (item, pos) =>
+		{
+			let	downButton;
+			if(this.props.isReadMode || (_items.length <= (pos + 1))){
+				downButton = (
+					<IconButton
+						disabled={ true }
+						{ ...theme.r3Resource.downAliasButton }
+						className={ classes.arrowInvisibleAliasButton }
+						size="large"
+					>
+						<DownIcon />
+					</IconButton>
+				);
+			}else{
+				downButton = (
+					<Tooltip
+						title={ r3provider.getR3TextRes().tResAliasDownTT }
+						open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.downAliasTooltip, 'number') || (this.state.tooltips.downAliasTooltip != pos)) ? false : true) }
+					>
 						<IconButton
-							disabled={ true }
+							onClick={ (event) => this.handleAliasesChange(event, actionTypeDown, pos) }
+							onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.downAliasTooltip, pos) }
+							onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.downAliasTooltip, -1) }
 							{ ...theme.r3Resource.downAliasButton }
-							className={ classes.arrowInvisibleAliasButton }
+							className={ classes.arrowAliasButton }
+							size="large"
 						>
 							<DownIcon />
 						</IconButton>
-					);
-				}else{
-					downButton = (
-						<Tooltip
-							title={ r3provider.getR3TextRes().tResAliasDownTT }
-							open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.downAliasTooltip, 'number') || (this.state.tooltips.downAliasTooltip != pos)) ? false : true) }
-						>
-							<IconButton
-								onClick={ (event) => this.handleAliasesChange(event, actionTypeDown, pos) }
-								onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.downAliasTooltip, pos) }
-								onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.downAliasTooltip, -1) }
-								{ ...theme.r3Resource.downAliasButton }
-								className={ classes.arrowAliasButton }
-							>
-								<DownIcon />
-							</IconButton>
-						</Tooltip>
-					);
-				}
+					</Tooltip>
+				);
+			}
 
-				let	upButton;
-				if(this.props.isReadMode || (0 === pos)){
-					upButton = (
+			let	upButton;
+			if(this.props.isReadMode || (0 === pos)){
+				upButton = (
+					<IconButton
+						disabled={ true }
+						{ ...theme.r3Resource.upAliasButton }
+						className={ classes.arrowInvisibleAliasButton }
+						size="large"
+					>
+						<UpIcon />
+					</IconButton>
+				);
+			}else{
+				upButton = (
+					<Tooltip
+						title={ r3provider.getR3TextRes().tResAliasUpTT }
+						open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.upAliasTooltip, 'number') || (this.state.tooltips.upAliasTooltip != pos)) ? false : true) }
+					>
 						<IconButton
-							disabled={ true }
+							onClick={ (event) => this.handleAliasesChange(event, actionTypeUp, pos) }
+							onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.upAliasTooltip, pos) }
+							onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.upAliasTooltip, -1) }
 							{ ...theme.r3Resource.upAliasButton }
-							className={ classes.arrowInvisibleAliasButton }
+							className={ classes.arrowAliasButton }
+							size="large"
 						>
 							<UpIcon />
 						</IconButton>
-					);
-				}else{
-					upButton = (
-						<Tooltip
-							title={ r3provider.getR3TextRes().tResAliasUpTT }
-							open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.upAliasTooltip, 'number') || (this.state.tooltips.upAliasTooltip != pos)) ? false : true) }
-						>
-							<IconButton
-								onClick={ (event) => this.handleAliasesChange(event, actionTypeUp, pos) }
-								onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.upAliasTooltip, pos) }
-								onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.upAliasTooltip, -1) }
-								{ ...theme.r3Resource.upAliasButton }
-								className={ classes.arrowAliasButton }
-							>
-								<UpIcon />
-							</IconButton>
-						</Tooltip>
-					);
-				}
+					</Tooltip>
+				);
+			}
 
-				let	deleteButton;
-				if(this.props.isReadMode){
-					deleteButton = (
+			let	deleteButton;
+			if(this.props.isReadMode){
+				deleteButton = (
+					<IconButton
+						disabled={ true }
+						{ ...theme.r3Resource.deleteAliasButton }
+						className={ classes.deleteInvisibleAliasButton }
+						size="large"
+					>
+						<DeleteIcon />
+					</IconButton>
+				);
+			}else{
+				deleteButton = (
+					<Tooltip
+						title={ r3provider.getR3TextRes().tResAliasDelTT }
+						open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.deleteAliasTooltip, 'number') || (this.state.tooltips.deleteAliasTooltip != pos)) ? false : true) }
+					>
 						<IconButton
-							disabled={ true }
+							onClick={ (event) => this.handleAliasesChange(event, actionTypeDelete, pos) }
+							onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.deleteAliasTooltip, pos) }
+							onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.deleteAliasTooltip, -1) }
 							{ ...theme.r3Resource.deleteAliasButton }
-							className={ classes.deleteInvisibleAliasButton }
+							className={ classes.deleteAliasButton }
+							size="large"
 						>
 							<DeleteIcon />
 						</IconButton>
-					);
-				}else{
-					deleteButton = (
-						<Tooltip
-							title={ r3provider.getR3TextRes().tResAliasDelTT }
-							open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.deleteAliasTooltip, 'number') || (this.state.tooltips.deleteAliasTooltip != pos)) ? false : true) }
-						>
-							<IconButton
-								onClick={ (event) => this.handleAliasesChange(event, actionTypeDelete, pos) }
-								onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.deleteAliasTooltip, pos) }
-								onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.deleteAliasTooltip, -1) }
-								{ ...theme.r3Resource.deleteAliasButton }
-								className={ classes.deleteAliasButton }
-							>
-								<DeleteIcon />
-							</IconButton>
-						</Tooltip>
-					);
-				}
-
-				let	inputProps;
-				if(this.props.isReadMode){
-					inputProps = {};
-				}else{
-					inputProps = {
-						className: classes.inputTextField
-					};
-				}
-
-				return (
-					<div
-						key={ pos }
-						className={ classes.enclosureElement }
-					>
-						<TextField
-							name={ resourceComponentValues.aliasTextFieldNamePrefix + String(pos) }
-							disabled={ this.props.isReadMode }
-							value={ item }
-							placeholder={ r3provider.getR3TextRes().tResAliasHint }
-							onChange={ (event) => this.handleAliasesChange(event, actionTypeValue, pos) }
-							InputProps={ inputProps }
-							{ ...theme.r3Resource.aliasTextField }
-							className={ classes.aliasTextField }
-						/>
-						{ downButton }
-						{ upButton }
-						{ deleteButton }
-					</div>
+					</Tooltip>
 				);
-			})
-		);
+			}
+
+			let	inputProps;
+			if(this.props.isReadMode){
+				inputProps = {};
+			}else{
+				inputProps = {
+					className: classes.inputTextField
+				};
+			}
+
+			return (
+				<div
+					key={ pos }
+					className={ classes.enclosureElement }
+				>
+					<TextField
+						name={ resourceComponentValues.aliasTextFieldNamePrefix + String(pos) }
+						disabled={ this.props.isReadMode }
+						value={ item }
+						placeholder={ r3provider.getR3TextRes().tResAliasHint }
+						onChange={ (event) => this.handleAliasesChange(event, actionTypeValue, pos) }
+						InputProps={ inputProps }
+						{ ...theme.r3Resource.aliasTextField }
+						className={ classes.aliasTextField }
+					/>
+					{ downButton }
+					{ upButton }
+					{ deleteButton }
+				</div>
+			);
+		});
 	}
 
 	getAddAliasContents()
@@ -1051,6 +1059,7 @@ export default class R3Resource extends React.Component
 						onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.addAliasTooltip, false) }
 						{ ...theme.r3Resource.addAliasButton }
 						className={ classes.addAliasButton }
+						size="large"
 					>
 						<AddIcon />
 					</IconButton>

--- a/src/components/r3role.jsx
+++ b/src/components/r3role.jsx
@@ -23,15 +23,16 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';						// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-import { withTheme, withStyles }	from '@material-ui/core/styles';		// decorator
-import TextField					from '@material-ui/core/TextField';
-import Typography					from '@material-ui/core/Typography';
-import IconButton					from '@material-ui/core/IconButton';
-import Tooltip						from '@material-ui/core/Tooltip';
-import DeleteIcon					from '@material-ui/icons/ClearRounded';
-import AddIcon						from '@material-ui/icons/AddRounded';
-import UpIcon						from '@material-ui/icons/ArrowUpwardRounded';
-import DownIcon						from '@material-ui/icons/ArrowDownwardRounded';
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import TextField					from '@mui/material/TextField';
+import Typography					from '@mui/material/Typography';
+import IconButton					from '@mui/material/IconButton';
+import Tooltip						from '@mui/material/Tooltip';
+import DeleteIcon					from '@mui/icons-material/ClearRounded';
+import AddIcon						from '@mui/icons-material/AddRounded';
+import UpIcon						from '@mui/icons-material/ArrowUpwardRounded';
+import DownIcon						from '@mui/icons-material/ArrowDownwardRounded';
 
 import { r3Role }					from './r3styles';
 import R3FormButtons				from './r3formbuttons';					// Buttons
@@ -1174,6 +1175,7 @@ export default class R3Role extends React.Component
 						disabled={ true }
 						{ ...theme.r3Role.deleteHostnameButton }
 						className={ classes.deleteInvisibleHostnameButton }
+						size="large"
 					>
 						<DeleteIcon />
 					</IconButton>
@@ -1190,6 +1192,7 @@ export default class R3Role extends React.Component
 							onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.deleteHostnameTooltip, -1) }
 							{ ...theme.r3Role.deleteHostnameButton }
 							className={ classes.deleteHostnameButton }
+							size="large"
 						>
 							<DeleteIcon />
 						</IconButton>
@@ -1283,6 +1286,7 @@ export default class R3Role extends React.Component
 						onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.addHostnameTooltip, false) }
 						{ ...theme.r3Role.addHostnameButton }
 						className={ classes.addHostnameButton }
+						size="large"
 					>
 						<AddIcon />
 					</IconButton>
@@ -1313,6 +1317,7 @@ export default class R3Role extends React.Component
 						disabled={ true }
 						{ ...theme.r3Role.deleteIpButton }
 						className={ classes.deleteInvisibleIpButton }
+						size="large"
 					>
 						<DeleteIcon />
 					</IconButton>
@@ -1329,6 +1334,7 @@ export default class R3Role extends React.Component
 							onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.deleteIpTooltip, -1) }
 							{ ...theme.r3Role.deleteIpButton }
 							className={ classes.deleteIpButton }
+							size="large"
 						>
 							<DeleteIcon />
 						</IconButton>
@@ -1379,68 +1385,68 @@ export default class R3Role extends React.Component
 		}
 		let	_items = items;
 
-		return (
-			_items.map( (item, pos) =>
-			{
-				let	deleteButton;
-				if(this.props.isReadMode){
-					deleteButton = (
+		return _items.map( (item, pos) =>
+		{
+			let	deleteButton;
+			if(this.props.isReadMode){
+				deleteButton = (
+					<IconButton
+						disabled={ true }
+						{ ...theme.r3Role.deletePolicyButton }
+						className={ classes.deleteInvisiblePolicyButton }
+						size="large"
+					>
+						<DeleteIcon />
+					</IconButton>
+				);
+			}else{
+				deleteButton = (
+					<Tooltip
+						title={ r3provider.getR3TextRes().tResRolePolicyDelTT }
+						open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.deletePolicyTooltip, 'number') || (this.state.tooltips.deletePolicyTooltip != pos)) ? false : true) }
+					>
 						<IconButton
-							disabled={ true }
+							onClick={ (event) => this.handlePoliciesChange(event, actionTypeDelete, pos) }
+							onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.deletePolicyTooltip, pos) }
+							onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.deletePolicyTooltip, -1) }
 							{ ...theme.r3Role.deletePolicyButton }
-							className={ classes.deleteInvisiblePolicyButton }
+							className={ classes.deletePolicyButton }
+							size="large"
 						>
 							<DeleteIcon />
 						</IconButton>
-					);
-				}else{
-					deleteButton = (
-						<Tooltip
-							title={ r3provider.getR3TextRes().tResRolePolicyDelTT }
-							open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.deletePolicyTooltip, 'number') || (this.state.tooltips.deletePolicyTooltip != pos)) ? false : true) }
-						>
-							<IconButton
-								onClick={ (event) => this.handlePoliciesChange(event, actionTypeDelete, pos) }
-								onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.deletePolicyTooltip, pos) }
-								onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.deletePolicyTooltip, -1) }
-								{ ...theme.r3Role.deletePolicyButton }
-								className={ classes.deletePolicyButton }
-							>
-								<DeleteIcon />
-							</IconButton>
-						</Tooltip>
-					);
-				}
-
-				let	inputProps;
-				if(this.props.isReadMode){
-					inputProps = {};
-				}else{
-					inputProps = {
-						className: classes.inputTextField
-					};
-				}
-
-				return (
-					<div
-						key={ pos }
-						className={ classes.enclosureElement }
-					>
-						<TextField
-							name={ roleComponentValues.policyTextFieldNamePrefix + String(pos) }
-							disabled={ this.props.isReadMode }
-							value={ item }
-							placeholder={ r3provider.getR3TextRes().tResRolePolicyHint }
-							onChange={ (event) => this.handlePoliciesChange(event, actionTypeValue, pos) }
-							InputProps={ inputProps }
-							{ ...theme.r3Role.policyTextField }
-							className={ classes.policyTextField }
-						/>
-						{ deleteButton }
-					</div>
+					</Tooltip>
 				);
-			})
-		);
+			}
+
+			let	inputProps;
+			if(this.props.isReadMode){
+				inputProps = {};
+			}else{
+				inputProps = {
+					className: classes.inputTextField
+				};
+			}
+
+			return (
+				<div
+					key={ pos }
+					className={ classes.enclosureElement }
+				>
+					<TextField
+						name={ roleComponentValues.policyTextFieldNamePrefix + String(pos) }
+						disabled={ this.props.isReadMode }
+						value={ item }
+						placeholder={ r3provider.getR3TextRes().tResRolePolicyHint }
+						onChange={ (event) => this.handlePoliciesChange(event, actionTypeValue, pos) }
+						InputProps={ inputProps }
+						{ ...theme.r3Role.policyTextField }
+						className={ classes.policyTextField }
+					/>
+					{ deleteButton }
+				</div>
+			);
+		});
 	}
 
 	getAddPolicyContents()
@@ -1474,6 +1480,7 @@ export default class R3Role extends React.Component
 						onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.addPolicyTooltip, false) }
 						{ ...theme.r3Role.addPolicyButton }
 						className={ classes.addPolicyButton }
+						size="large"
 					>
 						<AddIcon />
 					</IconButton>
@@ -1491,130 +1498,134 @@ export default class R3Role extends React.Component
 		}
 		let	_items = items;
 
-		return (
-			_items.map( (item, pos) =>
-			{
-				let	downButton;
-				if(this.props.isReadMode || (_items.length <= (pos + 1))){
-					downButton = (
+		return _items.map( (item, pos) =>
+		{
+			let	downButton;
+			if(this.props.isReadMode || (_items.length <= (pos + 1))){
+				downButton = (
+					<IconButton
+						disabled={ true }
+						{ ...theme.r3Role.downAliasButton }
+						className={ classes.arrowInvisibleAliasButton }
+						size="large"
+					>
+						<DownIcon />
+					</IconButton>
+				);
+			}else{
+				downButton = (
+					<Tooltip
+						title={ r3provider.getR3TextRes().tResAliasDownTT }
+						open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.downAliasTooltip, 'number') || (this.state.tooltips.downAliasTooltip != pos)) ? false : true) }
+					>
 						<IconButton
-							disabled={ true }
+							onClick={ (event) => this.handleAliasesChange(event, actionTypeDown, pos) }
+							onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.downAliasTooltip, pos) }
+							onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.downAliasTooltip, -1) }
 							{ ...theme.r3Role.downAliasButton }
-							className={ classes.arrowInvisibleAliasButton }
+							className={ classes.arrowAliasButton }
+							size="large"
 						>
 							<DownIcon />
 						</IconButton>
-					);
-				}else{
-					downButton = (
-						<Tooltip
-							title={ r3provider.getR3TextRes().tResAliasDownTT }
-							open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.downAliasTooltip, 'number') || (this.state.tooltips.downAliasTooltip != pos)) ? false : true) }
-						>
-							<IconButton
-								onClick={ (event) => this.handleAliasesChange(event, actionTypeDown, pos) }
-								onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.downAliasTooltip, pos) }
-								onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.downAliasTooltip, -1) }
-								{ ...theme.r3Role.downAliasButton }
-								className={ classes.arrowAliasButton }
-							>
-								<DownIcon />
-							</IconButton>
-						</Tooltip>
-					);
-				}
+					</Tooltip>
+				);
+			}
 
-				let	upButton;
-				if(this.props.isReadMode || (0 === pos)){
-					upButton = (
+			let	upButton;
+			if(this.props.isReadMode || (0 === pos)){
+				upButton = (
+					<IconButton
+						disabled={ true }
+						{ ...theme.r3Role.upAliasButton }
+						className={ classes.arrowInvisibleAliasButton }
+						size="large"
+					>
+						<UpIcon />
+					</IconButton>
+				);
+			}else{
+				upButton = (
+					<Tooltip
+						title={ r3provider.getR3TextRes().tResAliasUpTT }
+						open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.upAliasTooltip, 'number') || (this.state.tooltips.upAliasTooltip != pos)) ? false : true) }
+					>
 						<IconButton
-							disabled={ true }
+							onClick={ (event) => this.handleAliasesChange(event, actionTypeUp, pos) }
+							onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.upAliasTooltip, pos) }
+							onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.upAliasTooltip, -1) }
 							{ ...theme.r3Role.upAliasButton }
-							className={ classes.arrowInvisibleAliasButton }
+							className={ classes.arrowAliasButton }
+							size="large"
 						>
 							<UpIcon />
 						</IconButton>
-					);
-				}else{
-					upButton = (
-						<Tooltip
-							title={ r3provider.getR3TextRes().tResAliasUpTT }
-							open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.upAliasTooltip, 'number') || (this.state.tooltips.upAliasTooltip != pos)) ? false : true) }
-						>
-							<IconButton
-								onClick={ (event) => this.handleAliasesChange(event, actionTypeUp, pos) }
-								onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.upAliasTooltip, pos) }
-								onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.upAliasTooltip, -1) }
-								{ ...theme.r3Role.upAliasButton }
-								className={ classes.arrowAliasButton }
-							>
-								<UpIcon />
-							</IconButton>
-						</Tooltip>
-					);
-				}
+					</Tooltip>
+				);
+			}
 
-				let	deleteButton;
-				if(this.props.isReadMode){
-					deleteButton = (
+			let	deleteButton;
+			if(this.props.isReadMode){
+				deleteButton = (
+					<IconButton
+						disabled={ true }
+						{ ...theme.r3Role.deleteAliasButton }
+						className={ classes.deleteInvisibleAliasButton }
+						size="large"
+					>
+						<DeleteIcon />
+					</IconButton>
+				);
+			}else{
+				deleteButton = (
+					<Tooltip
+						title={ r3provider.getR3TextRes().tResAliasDelTT }
+						open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.deleteAliasTooltip, 'number') || (this.state.tooltips.deleteAliasTooltip != pos)) ? false : true) }
+					>
 						<IconButton
-							disabled={ true }
+							onClick={ (event) => this.handleAliasesChange(event, actionTypeDelete, pos) }
+							onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.deleteAliasTooltip, pos) }
+							onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.deleteAliasTooltip, -1) }
 							{ ...theme.r3Role.deleteAliasButton }
-							className={ classes.deleteInvisibleAliasButton }
+							className={ classes.deleteAliasButton }
+							size="large"
 						>
 							<DeleteIcon />
 						</IconButton>
-					);
-				}else{
-					deleteButton = (
-						<Tooltip
-							title={ r3provider.getR3TextRes().tResAliasDelTT }
-							open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.deleteAliasTooltip, 'number') || (this.state.tooltips.deleteAliasTooltip != pos)) ? false : true) }
-						>
-							<IconButton
-								onClick={ (event) => this.handleAliasesChange(event, actionTypeDelete, pos) }
-								onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.deleteAliasTooltip, pos) }
-								onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.deleteAliasTooltip, -1) }
-								{ ...theme.r3Role.deleteAliasButton }
-								className={ classes.deleteAliasButton }
-							>
-								<DeleteIcon />
-							</IconButton>
-						</Tooltip>
-					);
-				}
-
-				let	inputProps;
-				if(this.props.isReadMode){
-					inputProps = {};
-				}else{
-					inputProps = {
-						className: classes.inputTextField
-					};
-				}
-
-				return (
-					<div
-						key={ pos }
-						className={ classes.enclosureElement }
-					>
-						<TextField
-							name={ roleComponentValues.aliasTextFieldNamePrefix + String(pos) }
-							disabled={ this.props.isReadMode }
-							value={ item }
-							placeholder={ r3provider.getR3TextRes().tResAliasHint }
-							onChange={ (event) => this.handleAliasesChange(event, actionTypeValue, pos) }
-							InputProps={ inputProps }
-							{ ...theme.r3Role.aliasTextField }
-							className={ classes.aliasTextField }
-						/>
-						{ downButton }
-						{ upButton }
-						{ deleteButton }
-					</div>
+					</Tooltip>
 				);
-			})
-		);
+			}
+
+			let	inputProps;
+			if(this.props.isReadMode){
+				inputProps = {};
+			}else{
+				inputProps = {
+					className: classes.inputTextField
+				};
+			}
+
+			return (
+				<div
+					key={ pos }
+					className={ classes.enclosureElement }
+				>
+					<TextField
+						name={ roleComponentValues.aliasTextFieldNamePrefix + String(pos) }
+						disabled={ this.props.isReadMode }
+						value={ item }
+						placeholder={ r3provider.getR3TextRes().tResAliasHint }
+						onChange={ (event) => this.handleAliasesChange(event, actionTypeValue, pos) }
+						InputProps={ inputProps }
+						{ ...theme.r3Role.aliasTextField }
+						className={ classes.aliasTextField }
+					/>
+					{ downButton }
+					{ upButton }
+					{ deleteButton }
+				</div>
+			);
+		});
 	}
 
 	getAddAliasContents()
@@ -1648,6 +1659,7 @@ export default class R3Role extends React.Component
 						onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.addAliasTooltip, false) }
 						{ ...theme.r3Role.addAliasButton }
 						className={ classes.addAliasButton }
+						size="large"
 					>
 						<AddIcon />
 					</IconButton>

--- a/src/components/r3service.jsx
+++ b/src/components/r3service.jsx
@@ -23,24 +23,25 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';						// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-import { withTheme, withStyles }	from '@material-ui/core/styles';		// decorator
-import TextField					from '@material-ui/core/TextField';
-import Typography					from '@material-ui/core/Typography';
-import IconButton					from '@material-ui/core/IconButton';
-import Box							from '@material-ui/core/Box';
-import FormControlLabel				from '@material-ui/core/FormControlLabel';
-import RadioGroup					from '@material-ui/core/RadioGroup';
-import Radio						from '@material-ui/core/Radio';
-import Table						from '@material-ui/core/Table';
-import TableBody					from '@material-ui/core/TableBody';
-import TableCell					from '@material-ui/core/TableCell';
-import TableHead					from '@material-ui/core/TableHead';
-import TablePagination				from '@material-ui/core/TablePagination';
-import TableRow						from '@material-ui/core/TableRow';
-import Tooltip						from '@material-ui/core/Tooltip';
-import DeleteIcon					from '@material-ui/icons/ClearRounded';
-import AddIcon						from '@material-ui/icons/AddRounded';
-import EditIcon						from '@material-ui/icons/Edit';
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import TextField					from '@mui/material/TextField';
+import Typography					from '@mui/material/Typography';
+import IconButton					from '@mui/material/IconButton';
+import Box							from '@mui/material/Box';
+import FormControlLabel				from '@mui/material/FormControlLabel';
+import RadioGroup					from '@mui/material/RadioGroup';
+import Radio						from '@mui/material/Radio';
+import Table						from '@mui/material/Table';
+import TableBody					from '@mui/material/TableBody';
+import TableCell					from '@mui/material/TableCell';
+import TableHead					from '@mui/material/TableHead';
+import TablePagination				from '@mui/material/TablePagination';
+import TableRow						from '@mui/material/TableRow';
+import Tooltip						from '@mui/material/Tooltip';
+import DeleteIcon					from '@mui/icons-material/ClearRounded';
+import AddIcon						from '@mui/icons-material/AddRounded';
+import EditIcon						from '@mui/icons-material/Edit';
 
 import { r3Service }				from './r3styles';
 import R3FormButtons				from './r3formbuttons';					// Buttons
@@ -513,50 +514,49 @@ export default class R3Service extends React.Component
 
 		let	tenantYrn = regYrnTenantPathPrefix + this.props.tenant;
 
-		return (
-			items.map( (item, pos) =>
-			{
-				if(r3CompareCaseString(tenantYrn, item)){
-					// item is owner tenant, this value could not change.
-					return;
-				}
+		return items.map( (item, pos) =>
+		{
+			if(r3CompareCaseString(tenantYrn, item)){
+				// item is owner tenant, this value could not change.
+				return;
+			}
 
-				let	deleteButton = (
-					<Tooltip
-						title={ r3provider.getR3TextRes().tResServiceTenantDelTT }
-						open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.deleteTenantTooltip, 'number') || (this.state.tooltips.deleteTenantTooltip != pos)) ? false : true) }
+			let	deleteButton = (
+				<Tooltip
+					title={ r3provider.getR3TextRes().tResServiceTenantDelTT }
+					open={ ((r3IsEmptyEntityObject(this.state, 'tooltips') || !r3IsSafeTypedEntity(this.state.tooltips.deleteTenantTooltip, 'number') || (this.state.tooltips.deleteTenantTooltip != pos)) ? false : true) }
+				>
+					<IconButton
+						onClick={ (event) => this.handleTenantsChange(event, actionTypeDelete, pos) }
+						onMouseEnter={ (event) => this.handTooltipChange(event, tooltipValues.deleteTenantTooltip, pos) }
+						onMouseLeave={ (event) => this.handTooltipChange(event, tooltipValues.deleteTenantTooltip, -1) }
+						{ ...theme.r3Service.deleteTenantButton }
+						className={ classes.deleteTenantButton }
+						size="large"
 					>
-						<IconButton
-							onClick={ (event) => this.handleTenantsChange(event, actionTypeDelete, pos) }
-							onMouseEnter={ (event) => this.handTooltipChange(event, tooltipValues.deleteTenantTooltip, pos) }
-							onMouseLeave={ (event) => this.handTooltipChange(event, tooltipValues.deleteTenantTooltip, -1) }
-							{ ...theme.r3Service.deleteTenantButton }
-							className={ classes.deleteTenantButton }
-						>
-							<DeleteIcon />
-						</IconButton>
-					</Tooltip>
-				);
+						<DeleteIcon />
+					</IconButton>
+				</Tooltip>
+			);
 
-				return (
-					<div
-						key={ pos }
-						className={ classes.enclosureElement }
-					>
-						<TextField
-							name={ serviceComponentValues.tenantTextFieldNamePrefix + String(pos) }
-							value={ item }
-							placeholder={ r3provider.getR3TextRes().tResServiceTenantHint }
-							onChange={ (event) => this.handleTenantsChange(event, actionTypeValue, pos) }
-							InputProps={{ className: classes.inputTextField }}
-							{ ...theme.r3Service.tenantTextField }
-							className={ classes.tenantTextField }
-						/>
-						{ deleteButton }
-					</div>
-				);
-			})
-		);
+			return (
+				<div
+					key={ pos }
+					className={ classes.enclosureElement }
+				>
+					<TextField
+						name={ serviceComponentValues.tenantTextFieldNamePrefix + String(pos) }
+						value={ item }
+						placeholder={ r3provider.getR3TextRes().tResServiceTenantHint }
+						onChange={ (event) => this.handleTenantsChange(event, actionTypeValue, pos) }
+						InputProps={{ className: classes.inputTextField }}
+						{ ...theme.r3Service.tenantTextField }
+						className={ classes.tenantTextField }
+					/>
+					{ deleteButton }
+				</div>
+			);
+		});
 	}
 
 	getAddTenantsContents()
@@ -587,6 +587,7 @@ export default class R3Service extends React.Component
 						onMouseLeave={ (event) => this.handTooltipChange(event, tooltipValues.addTenantTooltip, false) }
 						{ ...theme.r3Service.addTenantButton }
 						className={ classes.addTenantButton }
+						size="large"
 					>
 						<AddIcon />
 					</IconButton>
@@ -850,6 +851,7 @@ export default class R3Service extends React.Component
 								onMouseLeave={ (event) => this.handTooltipChange(event, tooltipValues.addResStaticObjTooltip, false) }
 								{ ...theme.r3Service.addResStaticObjButton }
 								className={ classes.addResStaticObjButton }
+								size="large"
 							>
 								<AddIcon />
 							</IconButton>
@@ -941,6 +943,7 @@ export default class R3Service extends React.Component
 										onMouseLeave={ (event) => this.handTooltipChange(event, tooltipValues.delResStaticObjTooltip, -1) }
 										{ ...theme.r3Service.delResStaticObjButton }
 										className={ classes.delResStaticObjButton }
+										size="large"
 									>
 										<DeleteIcon />
 									</IconButton>
@@ -955,6 +958,7 @@ export default class R3Service extends React.Component
 										onMouseLeave={ (event) => this.handTooltipChange(event, tooltipValues.editResStaticObjTooltip, -1) }
 										{ ...theme.r3Service.editResStaticObjButton }
 										className={ classes.editResStaticObjButton }
+										size="large"
 									>
 										<EditIcon />
 									</IconButton>
@@ -996,7 +1000,7 @@ export default class R3Service extends React.Component
 					rowsPerPage={ this.props.tableRawCount }
 					page={ this.state.serviceResStaticObjPageNum }
 					rowsPerPageOptions={ [] }
-					onChangePage={ (event) => this.handleResStaticObjPageChange(event) }
+					onPageChange={ (event) => this.handleResStaticObjPageChange(event) }
 				/>
 				<TextField
 					name={ serviceComponentValues.resStaticObjTextFieldName }

--- a/src/components/r3signincreddialog.jsx
+++ b/src/components/r3signincreddialog.jsx
@@ -23,23 +23,24 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';						// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-import { withTheme, withStyles }	from '@material-ui/core/styles';		// decorator
-import TextField					from '@material-ui/core/TextField';
-import Button						from '@material-ui/core/Button';
-import IconButton					from '@material-ui/core/IconButton';
-import Dialog						from '@material-ui/core/Dialog';
-import DialogTitle					from '@material-ui/core/DialogTitle';
-import DialogContent				from '@material-ui/core/DialogContent';
-import DialogContentText			from '@material-ui/core/DialogContentText';
-import DialogActions				from '@material-ui/core/DialogActions';
-import InputAdornment				from '@material-ui/core/InputAdornment';
-import Typography					from '@material-ui/core/Typography';
-import Paper						from '@material-ui/core/Paper';
-import VisibilityIcon				from '@material-ui/icons/Visibility';
-import VisibilityOffIcon			from '@material-ui/icons/VisibilityOff';
-import CheckCircleIcon				from '@material-ui/icons/CheckCircle';
-import CancelIcon					from '@material-ui/icons/Cancel';
-import WarningIcon					from '@material-ui/icons/WarningRounded';
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import TextField					from '@mui/material/TextField';
+import Button						from '@mui/material/Button';
+import IconButton					from '@mui/material/IconButton';
+import Dialog						from '@mui/material/Dialog';
+import DialogTitle					from '@mui/material/DialogTitle';
+import DialogContent				from '@mui/material/DialogContent';
+import DialogContentText			from '@mui/material/DialogContentText';
+import DialogActions				from '@mui/material/DialogActions';
+import InputAdornment				from '@mui/material/InputAdornment';
+import Typography					from '@mui/material/Typography';
+import Paper						from '@mui/material/Paper';
+import VisibilityIcon				from '@mui/icons-material/Visibility';
+import VisibilityOffIcon			from '@mui/icons-material/VisibilityOff';
+import CheckCircleIcon				from '@mui/icons-material/CheckCircle';
+import CancelIcon					from '@mui/icons-material/Cancel';
+import WarningIcon					from '@mui/icons-material/WarningRounded';
 
 import { r3IsEmptyString }			from '../util/r3util';
 import { r3SigninCredDialogStyles }	from './r3styles';
@@ -231,6 +232,7 @@ export default class R3SigninCredDialog extends React.Component
 									<IconButton
 										onClick={ this.handleClickShowPassphrase }
 										{ ...theme.r3SigninCredDialog.passphraseIconButton }
+										size="large"
 									>
 										{ this.state.showPassphrase ? <VisibilityOffIcon /> : <VisibilityIcon />}
 									</IconButton>

--- a/src/components/r3styles.jsx
+++ b/src/components/r3styles.jsx
@@ -110,10 +110,10 @@ export const r3MainTree = (theme) => ({
 		paddingLeft:			theme.spacing(2)
 	},
 	serviceLabelCollapse: {
-		paddingLeft:			(theme.spacing(2) + theme.spacing(2) + theme.spacing(1))
+		paddingLeft:			theme.spacing(5)				// 2 + 2 + 1
 	},
 	childListItemText: {
-		marginLeft:				(theme.spacing(2) + theme.spacing(2) + theme.spacing(1))
+		marginLeft:				theme.spacing(5)				// 2 + 2 + 1
 	},
 	listItemText: {
 		paddingLeft:			0
@@ -122,7 +122,7 @@ export const r3MainTree = (theme) => ({
 		paddingLeft:			0
 	},
 	inServiceChildListItemText: {
-		marginLeft:				(theme.spacing(2) + theme.spacing(1))
+		marginLeft:				theme.spacing(3)				// 2 + 1
 	}
 });
 
@@ -160,6 +160,15 @@ export const r3Toolbar = (theme) => ({
 		//
 		width:					theme.spacing(3),				// 24px( as same as .MuiChip-avatar class value )
 		height:					theme.spacing(3),				// 24px( as same as .MuiChip-avatar class value )
+
+		// [NOTE][FIXME]
+		// In the migration to MUI v5, this Avatar has the default CSS of ".MuiChip-avatarColorPrimary" applied.
+		// And this default CSS couldn't be overridden by r3theme.jsx.
+		// Also, since this CSS is applied after style, it cannot be applied by r3style.jsx.
+		// Therefore, we chose a method that does not apply the default CSS using "StyledEngineProvider".
+		// Then, we added to set the following "margin-left" which was set in the default CSS.
+		//
+		marginLeft:				'5px'
 	},
 	descriptionIcon: {
 		color:					theme.palette.secondary.main
@@ -239,26 +248,26 @@ export const r3Resource = (theme) => ({
 	// [NOTE]
 	// If the content area is divided into two, the width of one is 50% width size
 	// (this value includes the padding size) minus the size of one half of the button.
-	// Since the button is 40px wide with padding 8px on (24x24)px, we need to subtract
-	// 20px. Because calc can not use variables, it uses numerical values.
+	// Since the button is 40px wide with padding 12px on (24x24)px, we need to subtract
+	// 30px. Because calc can not use variables, it uses numerical values.
 	//
 	keysKeySubTitle: {
 		float:					'left',
-		width:					`calc(50% - 20px)`,				// eslint-disable-line quotes
+		width:					`calc(50% - 30px)`,				// eslint-disable-line quotes
 		paddingLeft:			theme.spacing(6)
 	},
 	keysValueSubTitle: {
-		width:					`calc(50% - 20px)`,				// eslint-disable-line quotes
+		width:					`calc(50% - 30px)`,				// eslint-disable-line quotes
 		paddingLeft:			theme.spacing(2)
 	},
 	keysKeyTextField: {
 		float:					'left',
-		width:					`calc(50% - 20px)`,				// eslint-disable-line quotes
+		width:					`calc(50% - 30px)`,				// eslint-disable-line quotes
 		paddingLeft:			theme.spacing(6)
 	},
 	keysValueTextField: {
 		float:					'left',
-		width:					`calc(50% - 20px)`,				// eslint-disable-line quotes
+		width:					`calc(50% - 30px)`,				// eslint-disable-line quotes
 		paddingLeft:			theme.spacing(2)
 	},
 	deleteKeysButton: {
@@ -273,7 +282,7 @@ export const r3Resource = (theme) => ({
 	},
 	aliasTextField: {
 		float:					'left',
-		width:					`calc(100% - 120px)`,			// eslint-disable-line quotes
+		width:					`calc(100% - 150px)`,			// eslint-disable-line quotes
 		paddingLeft:			theme.spacing(6)
 	},
 	arrowAliasButton: {
@@ -287,7 +296,8 @@ export const r3Resource = (theme) => ({
 	},
 	addAliasButton: {
 		float:					'right',
-		display:				'flex'
+		display:				'flex',
+		paddingRight:			theme.spacing(3)
 	},
 	deleteAliasButton: {
 		display:				'flex'
@@ -344,7 +354,7 @@ export const r3Policy = (theme) => ({
 	//
 	resourceTextField: {
 		float:					'left',
-		width:					`calc(100% - 40px)`,			// eslint-disable-line quotes
+		width:					`calc(100% - 60px)`,			// eslint-disable-line quotes
 		paddingLeft:			theme.spacing(6)
 	},
 	addResourceButton: {
@@ -359,7 +369,7 @@ export const r3Policy = (theme) => ({
 	},
 	aliasTextField: {
 		float:					'left',
-		width:					`calc(100% - 120px)`,			// eslint-disable-line quotes
+		width:					`calc(100% - 150px)`,			// eslint-disable-line quotes
 		paddingLeft:			theme.spacing(6)
 	},
 	arrowAliasButton: {
@@ -373,7 +383,8 @@ export const r3Policy = (theme) => ({
 	},
 	addAliasButton: {
 		float:					'right',
-		display:				'flex'
+		display:				'flex',
+		paddingRight:			theme.spacing(3)
 	},
 	deleteAliasButton: {
 		display:				'flex'
@@ -414,21 +425,21 @@ export const r3Role = (theme) => ({
 	//
 	hostnameSubTitle: {
 		float:					'left',
-		width:					`calc(50% - 20px)`,				// eslint-disable-line quotes
+		width:					`calc(50% - 30px)`,				// eslint-disable-line quotes
 		paddingLeft:			theme.spacing(6)
 	},
 	hostnameAUXSubTitle: {
-		width:					`calc(50% - 20px)`,				// eslint-disable-line quotes
+		width:					`calc(50% - 30px)`,				// eslint-disable-line quotes
 		paddingLeft:			theme.spacing(2)
 	},
 	hostnameTextField: {
 		float:					'left',
-		width:					`calc(50% - 20px)`,				// eslint-disable-line quotes
+		width:					`calc(50% - 30px)`,				// eslint-disable-line quotes
 		paddingLeft:			theme.spacing(6)
 	},
 	hostnameAUXTextField: {
 		float:					'left',
-		width:					`calc(50% - 20px)`,				// eslint-disable-line quotes
+		width:					`calc(50% - 30px)`,				// eslint-disable-line quotes
 		paddingLeft:			theme.spacing(2)
 	},
 	deleteHostnameButton: {
@@ -443,21 +454,21 @@ export const r3Role = (theme) => ({
 	},
 	ipSubTitle: {
 		float:					'left',
-		width:					`calc(50% - 20px)`,				// eslint-disable-line quotes
+		width:					`calc(50% - 30px)`,				// eslint-disable-line quotes
 		paddingLeft:			theme.spacing(6)
 	},
 	ipAUXSubTitle: {
-		width:					`calc(50% - 20px)`,				// eslint-disable-line quotes
+		width:					`calc(50% - 30px)`,				// eslint-disable-line quotes
 		paddingLeft:			theme.spacing(2)
 	},
 	ipTextField: {
 		float:					'left',
-		width:					`calc(50% - 20px)`,				// eslint-disable-line quotes
+		width:					`calc(50% - 30px)`,				// eslint-disable-line quotes
 		paddingLeft:			theme.spacing(6)
 	},
 	ipAUXTextField: {
 		float:					'left',
-		width:					`calc(50% - 20px)`,				// eslint-disable-line quotes
+		width:					`calc(50% - 30px)`,				// eslint-disable-line quotes
 		paddingLeft:			theme.spacing(2)
 	},
 	deleteIpButton: {
@@ -469,7 +480,7 @@ export const r3Role = (theme) => ({
 	},
 	policyTextField: {
 		float:					'left',
-		width:					`calc(100% - 40px)`,			// eslint-disable-line quotes
+		width:					`calc(100% - 60px)`,			// eslint-disable-line quotes
 		paddingLeft:			theme.spacing(6)
 	},
 	addPolicyButton: {
@@ -484,7 +495,7 @@ export const r3Role = (theme) => ({
 	},
 	aliasTextField: {
 		float:					'left',
-		width:					`calc(100% - 120px)`,			// eslint-disable-line quotes
+		width:					`calc(100% - 150px)`,			// eslint-disable-line quotes
 		paddingLeft:			theme.spacing(6)
 	},
 	arrowAliasButton: {
@@ -498,7 +509,8 @@ export const r3Role = (theme) => ({
 	},
 	addAliasButton: {
 		float:					'right',
-		display:				'flex'
+		display:				'flex',
+		paddingRight:			theme.spacing(3)
 	},
 	deleteAliasButton: {
 		display:				'flex'
@@ -581,7 +593,7 @@ export const r3Service = (theme) => ({
 	},
 	tenantTextField: {
 		float:					'left',
-		width:					`calc(100% - 40px)`,			// eslint-disable-line quotes
+		width:					`calc(100% - 60px)`,			// eslint-disable-line quotes
 		paddingLeft:			theme.spacing(6)
 	},
 	addResStaticObjButton: {

--- a/src/components/r3theme.jsx
+++ b/src/components/r3theme.jsx
@@ -19,15 +19,15 @@
  *
  */
 
-import * as Colors		from '@material-ui/core/colors';
-import { createTheme }	from '@material-ui/core/styles';
+import * as Colors		from '@mui/material/colors';
+import { createTheme, adaptV4Theme } from '@mui/material/styles';
 
 /* eslint-disable indent */
 // [NOTE]
 // Default theme from material-ui
 // https://material-ui.com/customization/default-theme/
 //
-const r3Theme = createTheme({
+const r3Theme = createTheme(adaptV4Theme({
 	//
 	// palette
 	//
@@ -101,7 +101,10 @@ const r3Theme = createTheme({
 	//
 	// override components
 	//
-	overrides: {
+	// [NOTE]
+	// Changed "overrides" to "components" in the migration to MUI v5.
+	//
+	components: {
 		MuiIconButton: {
 			root: {
 				padding:			'8px'
@@ -111,6 +114,10 @@ const r3Theme = createTheme({
 		// [NOTE]
 		// @material-ui 4.x.x removed the default value of 'display: block' in Typography.
 		// Since K2HR3 is based on 'display: block', it is set in this overrides to maintain the layout.
+		//
+		// [NOTE][FIXME]
+		// Due to the migration to MUI v5, the following Typography overrides are no longer working.
+		// Instead, the display value is set in the individual Typography theme.
 		//
 		MuiTypography: {
 			root: {
@@ -123,9 +130,18 @@ const r3Theme = createTheme({
 		// But its backgroundColor is set theme.palette.primary.dark.
 		// We use avatar in chip only in toolbar, and it needs white.
 		//
+		// [NOTE][FIXME]
+		// Migrated to MUI v5 and changed "& $avatarColorPrimary" to "& .MuiChip-avatarColorPrimary".
+		// However, this MuiAvatar is used in R3Toolbar->MuiChip->Avatar, but we haven't been able
+		// to override this default CSS.
+		// Therefore, in MuiAvatar rendering(in r3toolbar.jsx), we defined "<StyledEngineProvider injectFirst>"
+		// and disabled this default CSS of MuiAvatar(Chip).
+		// Also, in the r3style.jsx file, marginLeft is added to the CSS of r3Toolbar->avatar to make
+		// it consistent.
+		//
 		MuiChip: {
 			root: {
-				'& $avatarColorPrimary': {
+				'& .MuiChip-avatarColorPrimary': {
 					backgroundColor:	Colors.common.white
 				}
 			}
@@ -155,7 +171,8 @@ const r3Theme = createTheme({
 		title: {
 			color:					'inherit',
 			variant:				'h6',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		mainMenuButton: {
 			color:					'inherit',
@@ -253,17 +270,20 @@ const r3Theme = createTheme({
 		},
 		chipText: {
 			variant:				'subtitle2',
-			component:				'span'
+			component:				'span',
+			display:				'block'
 		},
 		title: {
 			color:					'inherit',
 			variant:				'h6',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		tenantListText: {
 			color:					'textSecondary',
 			variant:				'subtitle2',
-			component:				'span'
+			component:				'span',
+			display:				'block'
 		},
 		tenantListButton: {
 			label:					'select-tenant',
@@ -345,7 +365,8 @@ const r3Theme = createTheme({
 			color:					'textSecondary',
 			variant:				'subtitle2',
 			component:				'span',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		chip: {
 			clickable:				true,
@@ -354,12 +375,14 @@ const r3Theme = createTheme({
 		},
 		chipText: {
 			variant:				'subtitle2',
-			component:				'span'
+			component:				'span',
+			display:				'block'
 		},
 		ownerText: {
 			variant:				'subtitle2',
 			component:				'span',
-			color:					'secondary'
+			color:					'secondary',
+			display:				'block'
 		},
 		toUpperPathButton: {
 			color:					'inherit',
@@ -387,13 +410,16 @@ const r3Theme = createTheme({
 		},
 		dialogErrorContentText: {
 			component:				'span',
-			color:					'error'
+			color:					'error',
+			display:				'block'
 		},
 		dialogWarningContentText: {
-			component:				'span'
+			component:				'span',
+			display:				'block'
 		},
 		dialogInformationContentText: {
-			component:				'span'
+			component:				'span',
+			display:				'block'
 		},
 		errorIcon: {
 			color:					'error'
@@ -413,7 +439,8 @@ const r3Theme = createTheme({
 		subTitle: {
 			variant:				'subtitle2',
 			color:					'primary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		valueFormControl: {
 		},
@@ -423,37 +450,44 @@ const r3Theme = createTheme({
 		valueFormControlLabel: {
 			variant:				'body1',
 			color:					'textSecondary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		valueLeftFormControlLabel: {
 		},
 		valueRightFormControlLabel: {
 		},
 		valueStringTextField: {
+			variant:				'standard',
 			fullWidth:				true,
 			multiline:				true,
 			minRows:				1,
 			maxRows:				10
 		},
 		valueObjectTextField: {
+			variant:				'standard',
 			fullWidth:				true,
 			multiline:				false
 		},
 		keysKeySubTitle: {
 			variant:				'body2',
 			color:					'textSecondary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		keysValueSubTitle: {
 			variant:				'body2',
 			color:					'textSecondary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		keysKeyTextField: {
+			variant:				'standard',
 			multiline:				false,
 			minRows:				1
 		},
 		keysValueTextField: {
+			variant:				'standard',
 			multiline:				false,
 			minRows:				1
 		},
@@ -466,6 +500,7 @@ const r3Theme = createTheme({
 			'aria-label':			'add key and value'
 		},
 		aliasTextField: {
+			variant:				'standard',
 			multiline:				false,
 			minRows:				1
 		},
@@ -496,9 +531,11 @@ const r3Theme = createTheme({
 		subTitle: {
 			variant:				'subtitle2',
 			color:					'primary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		effectSelect: {
+			variant:				'standard'
 		},
 		actionCheckbox: {
 		},
@@ -507,9 +544,11 @@ const r3Theme = createTheme({
 		actionFormControlLabel: {
 			variant:				'body2',
 			color:					'textSecondary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		resourceTextField: {
+			variant:				'standard',
 			multiline:				false,
 			minRows:				1
 		},
@@ -522,6 +561,7 @@ const r3Theme = createTheme({
 			'aria-label':			'delete resource'
 		},
 		aliasTextField: {
+			variant:				'standard',
 			multiline:				false,
 			minRows:				1
 		},
@@ -552,23 +592,28 @@ const r3Theme = createTheme({
 		subTitle: {
 			variant:				'subtitle2',
 			color:					'primary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		hostnameSubTitle: {
 			variant:				'body2',
 			color:					'textSecondary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		hostnameAUXSubTitle: {
 			variant:				'body2',
 			color:					'textSecondary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		hostnameTextField: {
+			variant:				'standard',
 			multiline:				false,
 			minRows:				1
 		},
 		hostnameAUXTextField: {
+			variant:				'standard',
 			multiline:				false,
 			minRows:				1
 		},
@@ -583,18 +628,22 @@ const r3Theme = createTheme({
 		ipSubTitle: {
 			variant:				'body2',
 			color:					'textSecondary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		ipAUXSubTitle: {
 			variant:				'body2',
 			color:					'textSecondary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		ipTextField: {
+			variant:				'standard',
 			multiline:				false,
 			minRows:				1
 		},
 		ipAUXTextField: {
+			variant:				'standard',
 			multiline:				false,
 			minRows:				1
 		},
@@ -607,6 +656,7 @@ const r3Theme = createTheme({
 			'aria-label':			'add ip and AUX'
 		},
 		policyTextField: {
+			variant:				'standard',
 			multiline:				false,
 			minRows:				1
 		},
@@ -620,6 +670,7 @@ const r3Theme = createTheme({
 		},
 
 		aliasTextField: {
+			variant:				'standard',
 			multiline:				false,
 			minRows:				1
 		},
@@ -650,9 +701,11 @@ const r3Theme = createTheme({
 		subTitle: {
 			variant:				'subtitle2',
 			color:					'primary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		resourceTextField: {
+			variant:				'standard',
 			multiline:				false,
 			minRows:				1
 		},
@@ -662,7 +715,8 @@ const r3Theme = createTheme({
 		valueFormControlLabel: {
 			variant:				'body1',
 			color:					'textSecondary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		valueLeftFormControlLabel: {
 		},
@@ -673,18 +727,22 @@ const r3Theme = createTheme({
 		textTableHead: {
 			variant:				'subtitle2',
 			component:				'span',
-			color:					'primary'
+			color:					'primary',
+			display:				'block'
 		},
 		textTableContent: {
 			variant:				'body1',
 			component:				'span',
-			color:					'textSecondary'
+			color:					'textSecondary',
+			display:				'block'
 		},
 		unknownMessage: {
 			variant:				'body1',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		tenantTextField: {
+			variant:				'standard',
 			multiline:				false,
 			minRows:				1
 		},
@@ -758,7 +816,8 @@ const r3Theme = createTheme({
 			variant:				'h5',
 			component:				'span',
 			color:					'primary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		dialogContentText: {
 			component:				'span'
@@ -771,11 +830,13 @@ const r3Theme = createTheme({
 		licenseType: {
 			variant:				'h6',
 			component:				'span',
-			color:					'textSecondary'
+			color:					'textSecondary',
+			display:				'block'
 		},
 		content: {
 			component:				'span',
-			variant:				'body2'
+			variant:				'body2',
+			display:				'block'
 		}
 	},
 
@@ -796,18 +857,21 @@ const r3Theme = createTheme({
 			variant:				'h5',
 			component:				'span',
 			color:					'primary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		subTitle: {
 			variant:				'subtitle2',
 			color:					'primary',
 			component:				'span',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		value: {
 			variant:				'body1',
 			component:				'span',
-			color:					'textSecondary'
+			color:					'textSecondary',
+			display:				'block'
 		},
 		unscopedtokenTextField: {
 			variant:				'outlined',
@@ -841,7 +905,8 @@ const r3Theme = createTheme({
 			variant:				'h5',
 			component:				'span',
 			color:					'primary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		dialogContentText: {
 			component:				'span'
@@ -852,12 +917,14 @@ const r3Theme = createTheme({
 		},
 		message: {
 			variant:				'body1',
-			color:					'error'
+			color:					'error',
+			display:				'block'
 		},
 		messageIcon: {
 			color:					'error'
 		},
 		textField: {
+			variant:				'standard',
 			margin:					'normal',
 			fullWidth:				true
 		},
@@ -897,17 +964,21 @@ const r3Theme = createTheme({
 			variant:				'h5',
 			component:				'span',
 			color:					'primary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		dialogErrorContentText: {
 			component:				'span',
-			color:					'error'
+			color:					'error',
+			display:				'block'
 		},
 		dialogWarningContentText: {
-			component:				'span'
+			component:				'span',
+			display:				'block'
 		},
 		dialogInformationContentText: {
-			component:				'span'
+			component:				'span',
+			display:				'block'
 		},
 		errorIcon: {
 			color:					'error'
@@ -945,18 +1016,21 @@ const r3Theme = createTheme({
 			variant:				'h5',
 			component:				'span',
 			color:					'primary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		keyTitle: {
 			variant:				'subtitle2',
 			color:					'primary',
 			component:				'span',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		value: {
 			variant:				'body1',
 			component:				'span',
-			color:					'textSecondary'
+			color:					'textSecondary',
+			display:				'block'
 		},
 		button: {
 			variant:				'contained',
@@ -983,12 +1057,20 @@ const r3Theme = createTheme({
 		textTableHead: {
 			variant:				'subtitle2',
 			component:				'span',
-			color:					'primary'
+			color:					'primary',
+			display:				'block'
 		},
 		textTableContent: {
 			variant:				'body1',
 			component:				'span',
-			color:					'textSecondary'
+			color:					'textSecondary',
+			display:				'block'
+		},
+		textNewTableContent: {
+			variant:				'body1',
+			component:				'span',
+			color:					'textSecondary',
+			display:				'block'
 		},
 		manageAddButton: {
 			color:					'primary',
@@ -1016,12 +1098,14 @@ const r3Theme = createTheme({
 			variant:				'subtitle2',
 			component:				'span',
 			color:					'primary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		newRoleTokenExpireLabel: {
 			variant:				'body1',
 			component:				'span',
-			color:					'textSecondary'
+			color:					'textSecondary',
+			display:				'block'
 		},
 		createRoleTokenButton: {
 			variant:				'contained',
@@ -1042,7 +1126,8 @@ const r3Theme = createTheme({
 			label:					'roletoken-clipboard-button',
 			'aria-label':			'copy roletoken to clipboard'
 		},
-		codetypeSelect: {
+		codeTypeSelect: {
+			variant:				'standard',
 			disabled:				false,
 			autoWidth:				true
 		},
@@ -1077,20 +1162,24 @@ const r3Theme = createTheme({
 			variant:				'h5',
 			component:				'span',
 			color:					'primary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		keyTitle: {
 			variant:				'subtitle2',
 			color:					'primary',
 			component:				'span',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		value: {
 			variant:				'body1',
 			component:				'span',
-			color:					'textSecondary'
+			color:					'textSecondary',
+			display:				'block'
 		},
 		textField: {
+			variant:				'standard',
 			disabled:				false,
 			inputProps: {
 				'aria-label':		'input create path',
@@ -1125,18 +1214,21 @@ const r3Theme = createTheme({
 			variant:				'h5',
 			component:				'span',
 			color:					'primary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		keyTitle: {
 			variant:				'subtitle2',
 			color:					'primary',
 			component:				'span',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		value: {
 			variant:				'body1',
 			component:				'span',
-			color:					'textSecondary'
+			color:					'textSecondary',
+			display:				'block'
 		},
 		valueRadioGroup: {
 			'aria-label':			'select type verify url or static resource'
@@ -1144,7 +1236,8 @@ const r3Theme = createTheme({
 		valueFormControlLabel: {
 			variant:				'body1',
 			color:					'textSecondary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		valueLeftFormControlLabel: {
 		},
@@ -1155,14 +1248,17 @@ const r3Theme = createTheme({
 		textTableHead: {
 			variant:				'subtitle2',
 			component:				'span',
-			color:					'primary'
+			color:					'primary',
+			display:				'block'
 		},
 		textTableContent: {
 			variant:				'body1',
 			component:				'span',
-			color:					'textSecondary'
+			color:					'textSecondary',
+			display:				'block'
 		},
 		textField: {
+			variant:				'standard',
 			disabled:				false,
 			multiline:				false,
 			minRows:				1
@@ -1198,7 +1294,8 @@ const r3Theme = createTheme({
 			variant:				'subtitle2',
 			component:				'span',
 			color:					'primary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		staticResKeyPopoverButton: {
 			variant:				'contained',
@@ -1209,11 +1306,13 @@ const r3Theme = createTheme({
 			variant:				'body1',
 			component:				'span',
 			color:					'primary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		staticResMessage: {
 			variant:				'body1',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		cancelButton: {
 			variant:				'contained',
@@ -1244,20 +1343,24 @@ const r3Theme = createTheme({
 			variant:				'h5',
 			component:				'span',
 			color:					'primary',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		keyTitle: {
 			variant:				'subtitle2',
 			color:					'primary',
 			component:				'span',
-			noWrap:					true
+			noWrap:					true,
+			display:				'block'
 		},
 		value: {
 			variant:				'body1',
 			component:				'span',
-			color:					'textSecondary'
+			color:					'textSecondary',
+			display:				'block'
 		},
 		textField: {
+			variant:				'standard',
 			disabled:				false
 		},
 		cancelButton: {
@@ -1271,7 +1374,7 @@ const r3Theme = createTheme({
 			'aria-label':			'ok'
 		}
 	}
-});
+}));
 /* eslint-enable indent */
 
 export default r3Theme;

--- a/src/components/r3toolbar.jsx
+++ b/src/components/r3toolbar.jsx
@@ -23,19 +23,21 @@ import React						from 'react';
 import ReactDOM						from 'react-dom';						// eslint-disable-line no-unused-vars
 import PropTypes					from 'prop-types';
 
-import { withTheme, withStyles }	from '@material-ui/core/styles';		// decorator
-import IconButton					from '@material-ui/core/IconButton';
-import Avatar						from '@material-ui/core/Avatar';
-import Chip							from '@material-ui/core/Chip';
-import AppBar						from '@material-ui/core/AppBar';
-import Toolbar						from '@material-ui/core/Toolbar';
-import Typography					from '@material-ui/core/Typography';
-import Tooltip						from '@material-ui/core/Tooltip';
+import { StyledEngineProvider }		from '@mui/material/styles';
+import withTheme					from '@mui/styles/withTheme';
+import withStyles					from '@mui/styles/withStyles';
+import IconButton					from '@mui/material/IconButton';
+import Avatar						from '@mui/material/Avatar';
+import Chip							from '@mui/material/Chip';
+import AppBar						from '@mui/material/AppBar';
+import Toolbar						from '@mui/material/Toolbar';
+import Typography					from '@mui/material/Typography';
+import Tooltip						from '@mui/material/Tooltip';
 
-import DescriptionIcon				from '@material-ui/icons/Description';
-import ArrowUpwardIcon				from '@material-ui/icons/ArrowUpwardRounded';
-import AddIcon						from '@material-ui/icons/AddRounded';
-import DeleteIcon					from '@material-ui/icons/ClearRounded';
+import DescriptionIcon				from '@mui/icons-material/Description';
+import ArrowUpwardIcon				from '@mui/icons-material/ArrowUpwardRounded';
+import AddIcon						from '@mui/icons-material/AddRounded';
+import DeleteIcon					from '@mui/icons-material/ClearRounded';
 
 import { r3Toolbar }				from './r3styles';
 import R3PathInfoDialog				from './r3pathinfodialog';
@@ -479,6 +481,7 @@ export default class R3Toolbar extends React.Component
 					onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.toUpperPath, true) }
 					onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.toUpperPath, false) }
 					{ ...theme.r3AppBar.toUpperPathButton }
+					size="large"
 				>
 					<ArrowUpwardIcon />
 				</IconButton>
@@ -518,6 +521,7 @@ export default class R3Toolbar extends React.Component
 					onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.createPath, true) }
 					onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.createPath, false) }
 					{ ...theme.r3AppBar.createPathButton }
+					size="large"
 				>
 					<AddIcon />
 				</IconButton>
@@ -598,6 +602,7 @@ export default class R3Toolbar extends React.Component
 					onMouseEnter={ event => this.handTooltipChange(event, tooltipValues.deletePath, true) }
 					onMouseLeave={ event => this.handTooltipChange(event, tooltipValues.deletePath, false) }
 					{ ...theme.r3AppBar.deletePathButton }
+					size="large"
 				>
 					<DeleteIcon />
 				</IconButton>
@@ -624,14 +629,24 @@ export default class R3Toolbar extends React.Component
 			strLabel = r3provider.getR3TextRes().tResTenantPathLabel;
 		}
 
+		// [NOTE][FIXME]
+		// In the migration to MUI v5, this Avatar has the default CSS of ".MuiChip-avatarColorPrimary" applied.
+		// And this default CSS couldn't be overridden by r3theme.jsx.
+		// Also, since this CSS is applied after style, it cannot be applied by r3style.jsx.
+		// Therefore, we chose a method that does not apply the default CSS using "StyledEngineProvider".
+		// Also, in the r3style.jsx file, marginLeft is added to the CSS of r3Toolbar->avatar to make
+		// it consistent.
+		//
 		let	avatar = (
-			<Avatar
-				className={ classes.avatar }
-			>
-				<DescriptionIcon
-					className={ classes.descriptionIcon }
-				/>
-			</Avatar>
+			<StyledEngineProvider injectFirst>
+				<Avatar
+					className={ classes.avatar }
+				>
+					<DescriptionIcon
+						className={ classes.descriptionIcon }
+					/>
+				</Avatar>
+			</StyledEngineProvider>
 		);
 
 		let	label = (

--- a/src/r3app.jsx
+++ b/src/r3app.jsx
@@ -23,20 +23,23 @@ import style				from '../public/css/style.css';						// eslint-disable-line no-u
 
 import React				from 'react';										// eslint-disable-line no-unused-vars
 import ReactDOM				from 'react-dom';
-import { ThemeProvider }	from '@material-ui/styles';							// for custom theme
-import CssBaseline			from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }	from '@mui/material/styles';
+//import { ThemeProvider }	from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';				// for jss and reset.css
 
 import r3Theme				from './components/r3theme';						// custom theme
 import R3Container			from './components/r3container';
 
 // Do render
 ReactDOM.render(
-	<ThemeProvider theme={ r3Theme } >
-		<CssBaseline />
-		<R3Container
-			title='K2HR3'
-		/>
-	</ThemeProvider>,
+	<StyledEngineProvider injectFirst>
+		<ThemeProvider theme={ r3Theme } >
+			<CssBaseline />
+			<R3Container
+				title='K2HR3'
+			/>
+		</ThemeProvider>
+	</StyledEngineProvider>,
 	document.getElementById('r3app')
 );
 

--- a/test/__tests__/__snapshots__/r3aboutdialog-test.jsx.snap
+++ b/test/__tests__/__snapshots__/r3aboutdialog-test.jsx.snap
@@ -2,341 +2,66 @@
 
 exports[`R3AboutDialog test snapshot for R3AboutDialog 1`] = `
 <
-  BackdropComponent={
-    Object {
-      "$$typeof": Symbol(react.forward_ref),
-      "Naked": Object {
-        "$$typeof": Symbol(react.forward_ref),
-        "propTypes": Object {
-          "children": [Function],
-          "className": [Function],
-          "classes": [Function],
-          "invisible": [Function],
-          "open": [Function],
-          "transitionDuration": [Function],
-        },
-        "render": [Function],
-      },
-      "options": Object {
-        "defaultTheme": Object {
-          "breakpoints": Object {
-            "between": [Function],
-            "down": [Function],
-            "keys": Array [
-              "xs",
-              "sm",
-              "md",
-              "lg",
-              "xl",
-            ],
-            "only": [Function],
-            "up": [Function],
-            "values": Object {
-              "lg": 1280,
-              "md": 960,
-              "sm": 600,
-              "xl": 1920,
-              "xs": 0,
-            },
-            "width": [Function],
-          },
-          "direction": "ltr",
-          "mixins": Object {
-            "gutters": [Function],
-            "toolbar": Object {
-              "@media (min-width:0px) and (orientation: landscape)": Object {
-                "minHeight": 48,
-              },
-              "@media (min-width:600px)": Object {
-                "minHeight": 64,
-              },
-              "minHeight": 56,
-            },
-          },
-          "overrides": Object {},
-          "palette": Object {
-            "action": Object {
-              "activatedOpacity": 0.12,
-              "active": "rgba(0, 0, 0, 0.54)",
-              "disabled": "rgba(0, 0, 0, 0.26)",
-              "disabledBackground": "rgba(0, 0, 0, 0.12)",
-              "disabledOpacity": 0.38,
-              "focus": "rgba(0, 0, 0, 0.12)",
-              "focusOpacity": 0.12,
-              "hover": "rgba(0, 0, 0, 0.04)",
-              "hoverOpacity": 0.04,
-              "selected": "rgba(0, 0, 0, 0.08)",
-              "selectedOpacity": 0.08,
-            },
-            "augmentColor": [Function],
-            "background": Object {
-              "default": "#fafafa",
-              "paper": "#fff",
-            },
-            "common": Object {
-              "black": "#000",
-              "white": "#fff",
-            },
-            "contrastThreshold": 3,
-            "divider": "rgba(0, 0, 0, 0.12)",
-            "error": Object {
-              "contrastText": "#fff",
-              "dark": "#d32f2f",
-              "light": "#e57373",
-              "main": "#f44336",
-            },
-            "getContrastText": [Function],
-            "grey": Object {
-              "100": "#f5f5f5",
-              "200": "#eeeeee",
-              "300": "#e0e0e0",
-              "400": "#bdbdbd",
-              "50": "#fafafa",
-              "500": "#9e9e9e",
-              "600": "#757575",
-              "700": "#616161",
-              "800": "#424242",
-              "900": "#212121",
-              "A100": "#d5d5d5",
-              "A200": "#aaaaaa",
-              "A400": "#303030",
-              "A700": "#616161",
-            },
-            "info": Object {
-              "contrastText": "#fff",
-              "dark": "#1976d2",
-              "light": "#64b5f6",
-              "main": "#2196f3",
-            },
-            "primary": Object {
-              "contrastText": "#fff",
-              "dark": "#303f9f",
-              "light": "#7986cb",
-              "main": "#3f51b5",
-            },
-            "secondary": Object {
-              "contrastText": "#fff",
-              "dark": "#c51162",
-              "light": "#ff4081",
-              "main": "#f50057",
-            },
-            "success": Object {
-              "contrastText": "rgba(0, 0, 0, 0.87)",
-              "dark": "#388e3c",
-              "light": "#81c784",
-              "main": "#4caf50",
-            },
-            "text": Object {
-              "disabled": "rgba(0, 0, 0, 0.38)",
-              "hint": "rgba(0, 0, 0, 0.38)",
-              "primary": "rgba(0, 0, 0, 0.87)",
-              "secondary": "rgba(0, 0, 0, 0.54)",
-            },
-            "tonalOffset": 0.2,
-            "type": "light",
-            "warning": Object {
-              "contrastText": "rgba(0, 0, 0, 0.87)",
-              "dark": "#f57c00",
-              "light": "#ffb74d",
-              "main": "#ff9800",
-            },
-          },
-          "props": Object {},
-          "shadows": Array [
-            "none",
-            "0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
-            "0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)",
-            "0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)",
-            "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
-            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
-            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
-            "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
-            "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
-            "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
-            "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
-            "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
-            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
-            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
-            "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
-            "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
-            "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
-            "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
-            "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
-            "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
-            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
-            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
-            "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
-            "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
-            "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
-          ],
-          "shape": Object {
-            "borderRadius": 4,
-          },
-          "spacing": [Function],
-          "transitions": Object {
-            "create": [Function],
-            "duration": Object {
-              "complex": 375,
-              "enteringScreen": 225,
-              "leavingScreen": 195,
-              "short": 250,
-              "shorter": 200,
-              "shortest": 150,
-              "standard": 300,
-            },
-            "easing": Object {
-              "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
-              "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
-              "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
-              "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
-            },
-            "getAutoHeightDuration": [Function],
-          },
-          "typography": Object {
-            "body1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00938em",
-              "lineHeight": 1.5,
-            },
-            "body2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.01071em",
-              "lineHeight": 1.43,
-            },
-            "button": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.02857em",
-              "lineHeight": 1.75,
-              "textTransform": "uppercase",
-            },
-            "caption": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.75rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.03333em",
-              "lineHeight": 1.66,
-            },
-            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-            "fontSize": 14,
-            "fontWeightBold": 700,
-            "fontWeightLight": 300,
-            "fontWeightMedium": 500,
-            "fontWeightRegular": 400,
-            "h1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "6rem",
-              "fontWeight": 300,
-              "letterSpacing": "-0.01562em",
-              "lineHeight": 1.167,
-            },
-            "h2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "3.75rem",
-              "fontWeight": 300,
-              "letterSpacing": "-0.00833em",
-              "lineHeight": 1.2,
-            },
-            "h3": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "3rem",
-              "fontWeight": 400,
-              "letterSpacing": "0em",
-              "lineHeight": 1.167,
-            },
-            "h4": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "2.125rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00735em",
-              "lineHeight": 1.235,
-            },
-            "h5": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1.5rem",
-              "fontWeight": 400,
-              "letterSpacing": "0em",
-              "lineHeight": 1.334,
-            },
-            "h6": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1.25rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.0075em",
-              "lineHeight": 1.6,
-            },
-            "htmlFontSize": 16,
-            "overline": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.75rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.08333em",
-              "lineHeight": 2.66,
-              "textTransform": "uppercase",
-            },
-            "pxToRem": [Function],
-            "round": [Function],
-            "subtitle1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00938em",
-              "lineHeight": 1.75,
-            },
-            "subtitle2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.00714em",
-              "lineHeight": 1.57,
-            },
-          },
-          "zIndex": Object {
-            "appBar": 1100,
-            "drawer": 1200,
-            "mobileStepper": 1000,
-            "modal": 1300,
-            "snackbar": 1400,
-            "speedDial": 1050,
-            "tooltip": 1500,
-          },
-        },
-        "name": "MuiBackdrop",
-      },
-      "propTypes": Object {
-        "classes": [Function],
-        "innerRef": [Function],
-      },
-      "render": [Function],
-      "useStyles": [Function],
-    }
-  }
-  BackdropProps={
-    Object {
-      "transitionDuration": Object {
-        "enter": 225,
-        "exit": 195,
-      },
-    }
-  }
   aria-label="about dialog"
-  className="MuiDialog-root R3AboutDialog-root-1"
+  className="MuiDialog-root R3AboutDialog-root-1 css-1h8td7x-MuiDialog-root"
   closeAfterTransition={true}
+  components={
+    Object {
+      "Backdrop": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "__emotion_base": Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "propTypes": Object {
+            "children": [Function],
+            "className": [Function],
+            "classes": [Function],
+            "component": [Function],
+            "components": [Function],
+            "componentsProps": [Function],
+            "invisible": [Function],
+            "open": [Function],
+            "sx": [Function],
+            "transitionDuration": [Function],
+          },
+          "render": [Function],
+        },
+        "__emotion_forwardProp": [Function],
+        "__emotion_real": [Circular],
+        "__emotion_styles": Array [
+          "label:MuiDialog-backdrop;",
+          Object {
+            "zIndex": -1,
+          },
+          [Function],
+        ],
+        "defaultProps": undefined,
+        "render": [Function],
+        "withComponent": [Function],
+      },
+    }
+  }
+  componentsProps={
+    Object {
+      "backdrop": Object {
+        "as": undefined,
+        "transitionDuration": Object {
+          "enter": 225,
+          "exit": 195,
+        },
+      },
+    }
+  }
   disableEscapeKeyDown={false}
   disablePortal={true}
   label="about-dialog"
+  onClick={[Function]}
   onClose={[Function]}
   open={true}
 >
   <
     appear={true}
     in={true}
-    role="none presentation"
+    role="presentation"
     timeout={
       Object {
         "enter": 225,
@@ -345,44 +70,39 @@ exports[`R3AboutDialog test snapshot for R3AboutDialog 1`] = `
     }
   >
     <div
-      className="MuiDialog-container MuiDialog-scrollBody"
+      className="MuiDialog-container MuiDialog-scrollBody css-iz3z40-MuiDialog-container"
       onMouseDown={[Function]}
-      onMouseUp={[Function]}
     >
       <div
-        className="MuiPaper-root MuiDialog-paper MuiDialog-paperScrollBody MuiDialog-paperWidthSm MuiDialog-paperFullWidth MuiPaper-elevation24 MuiPaper-rounded"
+        className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollBody MuiDialog-paperWidthSm MuiDialog-paperFullWidth css-zfoovh-MuiPaper-root-MuiDialog-paper"
         role="dialog"
       >
-        <div
-          className="MuiDialogTitle-root R3AboutDialog-dialogTitle-2"
+        <h2
+          className="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root R3AboutDialog-dialogTitle-2 css-bdhsul-MuiTypography-root-MuiDialogTitle-root"
           label="about-dialog"
         >
-          <h2
-            className="MuiTypography-root MuiTypography-h6"
+          <span
+            className="MuiTypography-root MuiTypography-h5 MuiTypography-noWrap R3AboutDialog-title-3 css-idtq1y-MuiTypography-root"
           >
-            <span
-              className="MuiTypography-root R3AboutDialog-title-3 MuiTypography-h5 MuiTypography-colorPrimary MuiTypography-noWrap"
-            >
-              About 
-              K2HR3
-            </span>
-          </h2>
-        </div>
+            About 
+            K2HR3
+          </span>
+        </h2>
         <div
-          className="MuiDialogContent-root R3AboutDialog-dialogContent-4"
+          className="MuiDialogContent-root R3AboutDialog-dialogContent-4 css-ypiqx9-MuiDialogContent-root"
         >
           <span
-            className="MuiTypography-root MuiDialogContentText-root R3AboutDialog-dialogContentText-5 MuiTypography-body1 MuiTypography-colorTextSecondary"
+            className="MuiDialogContentText-root MuiTypography-root MuiTypography-body1 R3AboutDialog-dialogContentText-5 css-qfso29-MuiTypography-root-MuiDialogContentText-root"
           >
             <span
-              className="MuiTypography-root MuiTypography-h6 MuiTypography-colorTextSecondary"
+              className="MuiTypography-root MuiTypography-h6 css-cbexrx-MuiTypography-root"
             >
               License: 
               MIT
               <br />
             </span>
             <span
-              className="MuiTypography-root MuiTypography-body2"
+              className="MuiTypography-root MuiTypography-body2 css-et1ao3-MuiTypography-root"
             >
               K2HR3 is K2hdkc based Resource and Roles and policy Rules, gathers commonmanagement information for the cloud.K2HR3 can dynamically manage information as "who", "what", "operate".These are stored as roles, resources, policies in K2hdkc, and the clientsystem can dynamically read and modify these information.
               <br />
@@ -392,14 +112,15 @@ exports[`R3AboutDialog test snapshot for R3AboutDialog 1`] = `
           </span>
         </div>
         <div
-          className="MuiDialogActions-root R3AboutDialog-dialogAction-6 MuiDialogActions-spacing"
+          className="MuiDialogActions-root MuiDialogActions-spacing R3AboutDialog-dialogAction-6 css-hlj6pa-MuiDialogActions-root"
         >
           <button
             aria-label="close about dialog"
-            className="MuiButtonBase-root MuiButton-root MuiButton-contained R3AboutDialog-button-7 MuiButton-containedSecondary"
+            className="MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root R3AboutDialog-button-7 css-zcbmsk-MuiButtonBase-root-MuiButton-root"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
+            onContextMenu={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -413,21 +134,18 @@ exports[`R3AboutDialog test snapshot for R3AboutDialog 1`] = `
             tabIndex={0}
             type="button"
           >
-            <span
-              className="MuiButton-label"
+            CLOSE
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3AboutDialog-buttonIcon-8 css-i4bv87-MuiSvgIcon-root"
+              data-testid="CancelIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              CLOSE
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root R3AboutDialog-buttonIcon-8"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
-                />
-              </svg>
-            </span>
+              <path
+                d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+              />
+            </svg>
           </button>
         </div>
       </div>

--- a/test/__tests__/__snapshots__/r3accountdialog-test.jsx.snap
+++ b/test/__tests__/__snapshots__/r3accountdialog-test.jsx.snap
@@ -2,340 +2,66 @@
 
 exports[`R3AccountDialog test snapshot for R3AccountDialog 1`] = `
 <
-  BackdropComponent={
-    Object {
-      "$$typeof": Symbol(react.forward_ref),
-      "Naked": Object {
-        "$$typeof": Symbol(react.forward_ref),
-        "propTypes": Object {
-          "children": [Function],
-          "className": [Function],
-          "classes": [Function],
-          "invisible": [Function],
-          "open": [Function],
-          "transitionDuration": [Function],
-        },
-        "render": [Function],
-      },
-      "options": Object {
-        "defaultTheme": Object {
-          "breakpoints": Object {
-            "between": [Function],
-            "down": [Function],
-            "keys": Array [
-              "xs",
-              "sm",
-              "md",
-              "lg",
-              "xl",
-            ],
-            "only": [Function],
-            "up": [Function],
-            "values": Object {
-              "lg": 1280,
-              "md": 960,
-              "sm": 600,
-              "xl": 1920,
-              "xs": 0,
-            },
-            "width": [Function],
-          },
-          "direction": "ltr",
-          "mixins": Object {
-            "gutters": [Function],
-            "toolbar": Object {
-              "@media (min-width:0px) and (orientation: landscape)": Object {
-                "minHeight": 48,
-              },
-              "@media (min-width:600px)": Object {
-                "minHeight": 64,
-              },
-              "minHeight": 56,
-            },
-          },
-          "overrides": Object {},
-          "palette": Object {
-            "action": Object {
-              "activatedOpacity": 0.12,
-              "active": "rgba(0, 0, 0, 0.54)",
-              "disabled": "rgba(0, 0, 0, 0.26)",
-              "disabledBackground": "rgba(0, 0, 0, 0.12)",
-              "disabledOpacity": 0.38,
-              "focus": "rgba(0, 0, 0, 0.12)",
-              "focusOpacity": 0.12,
-              "hover": "rgba(0, 0, 0, 0.04)",
-              "hoverOpacity": 0.04,
-              "selected": "rgba(0, 0, 0, 0.08)",
-              "selectedOpacity": 0.08,
-            },
-            "augmentColor": [Function],
-            "background": Object {
-              "default": "#fafafa",
-              "paper": "#fff",
-            },
-            "common": Object {
-              "black": "#000",
-              "white": "#fff",
-            },
-            "contrastThreshold": 3,
-            "divider": "rgba(0, 0, 0, 0.12)",
-            "error": Object {
-              "contrastText": "#fff",
-              "dark": "#d32f2f",
-              "light": "#e57373",
-              "main": "#f44336",
-            },
-            "getContrastText": [Function],
-            "grey": Object {
-              "100": "#f5f5f5",
-              "200": "#eeeeee",
-              "300": "#e0e0e0",
-              "400": "#bdbdbd",
-              "50": "#fafafa",
-              "500": "#9e9e9e",
-              "600": "#757575",
-              "700": "#616161",
-              "800": "#424242",
-              "900": "#212121",
-              "A100": "#d5d5d5",
-              "A200": "#aaaaaa",
-              "A400": "#303030",
-              "A700": "#616161",
-            },
-            "info": Object {
-              "contrastText": "#fff",
-              "dark": "#1976d2",
-              "light": "#64b5f6",
-              "main": "#2196f3",
-            },
-            "primary": Object {
-              "contrastText": "#fff",
-              "dark": "#303f9f",
-              "light": "#7986cb",
-              "main": "#3f51b5",
-            },
-            "secondary": Object {
-              "contrastText": "#fff",
-              "dark": "#c51162",
-              "light": "#ff4081",
-              "main": "#f50057",
-            },
-            "success": Object {
-              "contrastText": "rgba(0, 0, 0, 0.87)",
-              "dark": "#388e3c",
-              "light": "#81c784",
-              "main": "#4caf50",
-            },
-            "text": Object {
-              "disabled": "rgba(0, 0, 0, 0.38)",
-              "hint": "rgba(0, 0, 0, 0.38)",
-              "primary": "rgba(0, 0, 0, 0.87)",
-              "secondary": "rgba(0, 0, 0, 0.54)",
-            },
-            "tonalOffset": 0.2,
-            "type": "light",
-            "warning": Object {
-              "contrastText": "rgba(0, 0, 0, 0.87)",
-              "dark": "#f57c00",
-              "light": "#ffb74d",
-              "main": "#ff9800",
-            },
-          },
-          "props": Object {},
-          "shadows": Array [
-            "none",
-            "0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
-            "0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)",
-            "0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)",
-            "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
-            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
-            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
-            "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
-            "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
-            "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
-            "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
-            "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
-            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
-            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
-            "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
-            "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
-            "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
-            "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
-            "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
-            "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
-            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
-            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
-            "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
-            "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
-            "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
-          ],
-          "shape": Object {
-            "borderRadius": 4,
-          },
-          "spacing": [Function],
-          "transitions": Object {
-            "create": [Function],
-            "duration": Object {
-              "complex": 375,
-              "enteringScreen": 225,
-              "leavingScreen": 195,
-              "short": 250,
-              "shorter": 200,
-              "shortest": 150,
-              "standard": 300,
-            },
-            "easing": Object {
-              "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
-              "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
-              "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
-              "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
-            },
-            "getAutoHeightDuration": [Function],
-          },
-          "typography": Object {
-            "body1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00938em",
-              "lineHeight": 1.5,
-            },
-            "body2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.01071em",
-              "lineHeight": 1.43,
-            },
-            "button": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.02857em",
-              "lineHeight": 1.75,
-              "textTransform": "uppercase",
-            },
-            "caption": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.75rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.03333em",
-              "lineHeight": 1.66,
-            },
-            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-            "fontSize": 14,
-            "fontWeightBold": 700,
-            "fontWeightLight": 300,
-            "fontWeightMedium": 500,
-            "fontWeightRegular": 400,
-            "h1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "6rem",
-              "fontWeight": 300,
-              "letterSpacing": "-0.01562em",
-              "lineHeight": 1.167,
-            },
-            "h2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "3.75rem",
-              "fontWeight": 300,
-              "letterSpacing": "-0.00833em",
-              "lineHeight": 1.2,
-            },
-            "h3": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "3rem",
-              "fontWeight": 400,
-              "letterSpacing": "0em",
-              "lineHeight": 1.167,
-            },
-            "h4": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "2.125rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00735em",
-              "lineHeight": 1.235,
-            },
-            "h5": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1.5rem",
-              "fontWeight": 400,
-              "letterSpacing": "0em",
-              "lineHeight": 1.334,
-            },
-            "h6": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1.25rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.0075em",
-              "lineHeight": 1.6,
-            },
-            "htmlFontSize": 16,
-            "overline": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.75rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.08333em",
-              "lineHeight": 2.66,
-              "textTransform": "uppercase",
-            },
-            "pxToRem": [Function],
-            "round": [Function],
-            "subtitle1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00938em",
-              "lineHeight": 1.75,
-            },
-            "subtitle2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.00714em",
-              "lineHeight": 1.57,
-            },
-          },
-          "zIndex": Object {
-            "appBar": 1100,
-            "drawer": 1200,
-            "mobileStepper": 1000,
-            "modal": 1300,
-            "snackbar": 1400,
-            "speedDial": 1050,
-            "tooltip": 1500,
-          },
-        },
-        "name": "MuiBackdrop",
-      },
-      "propTypes": Object {
-        "classes": [Function],
-        "innerRef": [Function],
-      },
-      "render": [Function],
-      "useStyles": [Function],
-    }
-  }
-  BackdropProps={
-    Object {
-      "transitionDuration": Object {
-        "enter": 225,
-        "exit": 195,
-      },
-    }
-  }
   aria-label="account dialog"
-  className="MuiDialog-root R3AccountDialog-root-1"
+  className="MuiDialog-root R3AccountDialog-root-1 css-1h8td7x-MuiDialog-root"
   closeAfterTransition={true}
+  components={
+    Object {
+      "Backdrop": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "__emotion_base": Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "propTypes": Object {
+            "children": [Function],
+            "className": [Function],
+            "classes": [Function],
+            "component": [Function],
+            "components": [Function],
+            "componentsProps": [Function],
+            "invisible": [Function],
+            "open": [Function],
+            "sx": [Function],
+            "transitionDuration": [Function],
+          },
+          "render": [Function],
+        },
+        "__emotion_forwardProp": [Function],
+        "__emotion_real": [Circular],
+        "__emotion_styles": Array [
+          "label:MuiDialog-backdrop;",
+          Object {
+            "zIndex": -1,
+          },
+          [Function],
+        ],
+        "defaultProps": undefined,
+        "render": [Function],
+        "withComponent": [Function],
+      },
+    }
+  }
+  componentsProps={
+    Object {
+      "backdrop": Object {
+        "as": undefined,
+        "transitionDuration": Object {
+          "enter": 225,
+          "exit": 195,
+        },
+      },
+    }
+  }
   disableEscapeKeyDown={false}
+  disablePortal={true}
   label="account-dialog"
+  onClick={[Function]}
   onClose={[Function]}
   open={true}
 >
   <
     appear={true}
     in={true}
-    role="none presentation"
+    role="presentation"
     timeout={
       Object {
         "enter": 225,
@@ -344,58 +70,56 @@ exports[`R3AccountDialog test snapshot for R3AccountDialog 1`] = `
     }
   >
     <div
-      className="MuiDialog-container MuiDialog-scrollBody"
+      className="MuiDialog-container MuiDialog-scrollBody css-iz3z40-MuiDialog-container"
       onMouseDown={[Function]}
-      onMouseUp={[Function]}
     >
       <div
-        className="MuiPaper-root MuiDialog-paper MuiDialog-paperScrollBody MuiDialog-paperWidthSm MuiDialog-paperFullWidth MuiPaper-elevation24 MuiPaper-rounded"
+        aria-labelledby="mui-3"
+        className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollBody MuiDialog-paperWidthSm MuiDialog-paperFullWidth css-zfoovh-MuiPaper-root-MuiDialog-paper"
         role="dialog"
       >
-        <div
-          className="MuiDialogTitle-root R3AccountDialog-dialogTitle-2"
+        <h2
+          className="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root R3AccountDialog-dialogTitle-2 css-bdhsul-MuiTypography-root-MuiDialogTitle-root"
+          id="mui-3"
           label="account-dialog"
         >
-          <h2
-            className="MuiTypography-root MuiTypography-h6"
+          <span
+            className="MuiTypography-root MuiTypography-h5 MuiTypography-noWrap R3AccountDialog-title-3 css-idtq1y-MuiTypography-root"
           >
-            <span
-              className="MuiTypography-root R3AccountDialog-title-3 MuiTypography-h5 MuiTypography-colorPrimary MuiTypography-noWrap"
-            >
-              Account Information
-            </span>
-          </h2>
-        </div>
+            Account Information
+          </span>
+        </h2>
         <div
-          className="MuiDialogContent-root R3AccountDialog-dialogContent-4"
+          className="MuiDialogContent-root R3AccountDialog-dialogContent-4 css-ypiqx9-MuiDialogContent-root"
         >
           <span
-            className="MuiTypography-root R3AccountDialog-subTitle-5 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3AccountDialog-subTitle-5 css-qxncr6-MuiTypography-root"
           >
             User name
           </span>
           <span
-            className="MuiTypography-root R3AccountDialog-value-6 MuiTypography-body1 MuiTypography-colorTextSecondary"
+            className="MuiTypography-root MuiTypography-body1 R3AccountDialog-value-6 css-nrdprl-MuiTypography-root"
           >
             JEST_TEST_USERNAME
           </span>
           <span
-            className="MuiTypography-root R3AccountDialog-subTitle-5 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3AccountDialog-subTitle-5 css-qxncr6-MuiTypography-root"
           >
             Unscoped Token
           </span>
           <div
-            className="MuiFormControl-root MuiTextField-root R3AccountDialog-unscopedtokenTextField-11 MuiFormControl-fullWidth"
+            className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root R3AccountDialog-unscopedtokenTextField-11 css-wb57ya-MuiFormControl-root-MuiTextField-root"
           >
             <div
-              className="MuiInputBase-root MuiOutlinedInput-root R3AccountDialog-unscopedtokenInputTextField-10 MuiInputBase-fullWidth MuiInputBase-formControl"
+              className="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl R3AccountDialog-unscopedtokenInputTextField-10 css-md26zr-MuiInputBase-root-MuiOutlinedInput-root"
               onClick={[Function]}
             >
               <input
                 aria-invalid={false}
                 autoFocus={false}
-                className="MuiInputBase-input MuiOutlinedInput-input"
+                className="MuiOutlinedInput-input MuiInputBase-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
                 disabled={false}
+                id="mui-1"
                 name="unscopedtoken-textfield"
                 onAnimationStart={[Function]}
                 onBlur={[Function]}
@@ -412,38 +136,29 @@ exports[`R3AccountDialog test snapshot for R3AccountDialog 1`] = `
               />
               <fieldset
                 aria-hidden={true}
-                className="PrivateNotchedOutline-root-14 MuiOutlinedInput-notchedOutline"
-                style={
-                  Object {
-                    "paddingLeft": 8,
-                  }
-                }
+                className="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
               >
                 <legend
-                  className="PrivateNotchedOutline-legend-15"
-                  style={
-                    Object {
-                      "width": 0.01,
-                    }
-                  }
+                  className="css-hdw1oc"
                 >
                   <span
-                    dangerouslySetInnerHTML={
-                      Object {
-                        "__html": "&#8203;",
-                      }
-                    }
-                  />
+                    className="notranslate"
+                  >
+                    ​
+                  </span>
                 </legend>
               </fieldset>
             </div>
           </div>
           <button
-            aria-describedby={null}
-            className="MuiButtonBase-root MuiButton-root MuiButton-text R3AccountDialog-copyClipboardButton-12"
+            aria-label="Copy to clipboard"
+            aria-labelledby={null}
+            className="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root R3AccountDialog-copyClipboardButton-12 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+            data-mui-internal-clone-element={true}
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
+            onContextMenu={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -457,38 +172,35 @@ exports[`R3AccountDialog test snapshot for R3AccountDialog 1`] = `
             onTouchMove={[Function]}
             onTouchStart={[Function]}
             tabIndex={0}
-            title="Copy to clipboard"
             type="button"
           >
-            <span
-              className="MuiButton-label"
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3AccountDialog-copyClipboardIcon-13 css-i4bv87-MuiSvgIcon-root"
+              data-testid="AssignmentTurnedInRoundedIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root R3AccountDialog-copyClipboardIcon-13"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M19 3h-4.18C14.4 1.84 13.3 1 12 1s-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zM9.29 16.29L6.7 13.7a.9959.9959 0 010-1.41c.39-.39 1.02-.39 1.41 0L10 14.17l5.88-5.88c.39-.39 1.02-.39 1.41 0 .39.39.39 1.02 0 1.41l-6.59 6.59c-.38.39-1.02.39-1.41 0z"
-                />
-              </svg>
-              Copy to clipboard
-            </span>
+              <path
+                d="M19 3h-4.18C14.4 1.84 13.3 1 12 1s-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zM9.29 16.29 6.7 13.7a.9959.9959 0 0 1 0-1.41c.39-.39 1.02-.39 1.41 0L10 14.17l5.88-5.88c.39-.39 1.02-.39 1.41 0 .39.39.39 1.02 0 1.41l-6.59 6.59c-.38.39-1.02.39-1.41 0z"
+              />
+            </svg>
+            Copy to clipboard
             <span
-              className="MuiTouchRipple-root"
+              className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
             />
           </button>
         </div>
         <div
-          className="MuiDialogActions-root MuiDialogActions-spacing"
+          className="MuiDialogActions-root MuiDialogActions-spacing css-hlj6pa-MuiDialogActions-root"
         >
           <button
             aria-label="ok"
-            className="MuiButtonBase-root MuiButton-root MuiButton-contained R3AccountDialog-okButton-8 MuiButton-containedSecondary"
+            className="MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root R3AccountDialog-okButton-8 css-zcbmsk-MuiButtonBase-root-MuiButton-root"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
+            onContextMenu={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -502,23 +214,20 @@ exports[`R3AccountDialog test snapshot for R3AccountDialog 1`] = `
             tabIndex={0}
             type="button"
           >
-            <span
-              className="MuiButton-label"
+            OK
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3AccountDialog-buttonIcon-9 css-i4bv87-MuiSvgIcon-root"
+              data-testid="CheckCircleIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              OK
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root R3AccountDialog-buttonIcon-9"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                />
-              </svg>
-            </span>
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+              />
+            </svg>
             <span
-              className="MuiTouchRipple-root"
+              className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
             />
           </button>
         </div>

--- a/test/__tests__/__snapshots__/r3appbar-test.jsx.snap
+++ b/test/__tests__/__snapshots__/r3appbar-test.jsx.snap
@@ -2,20 +2,22 @@
 
 exports[`R3AppBar test snapshot for R3AppBar 1`] = `
 <header
-  className="MuiPaper-root MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary R3AppBar-root-1 MuiPaper-elevation4"
+  className="MuiPaper-root MuiPaper-elevation MuiPaper-elevation4 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionStatic R3AppBar-root-1 css-hip9hq-MuiPaper-root-MuiAppBar-root"
 >
   <div
-    className="MuiToolbar-root MuiToolbar-dense R3AppBar-toolbar-2 MuiToolbar-gutters"
+    className="MuiToolbar-root MuiToolbar-gutters MuiToolbar-dense R3AppBar-toolbar-2 css-10ltm04-MuiToolbar-root"
   >
     <button
-      aria-describedby={null}
       aria-haspopup="true"
       aria-label="main menu"
-      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeLarge css-1pz7awu-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="main-menu"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -29,41 +31,39 @@ exports[`R3AppBar test snapshot for R3AppBar 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Main menu"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="MenuIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
     <h6
-      className="MuiTypography-root R3AppBar-title-3 MuiTypography-h6 MuiTypography-colorInherit MuiTypography-noWrap"
+      className="MuiTypography-root MuiTypography-h6 MuiTypography-noWrap R3AppBar-title-3 css-8uzb32-MuiTypography-root"
     >
       K2HR3
     </h6>
     <button
-      aria-describedby={null}
       aria-haspopup="true"
       aria-label="signin menu"
-      className="MuiButtonBase-root MuiIconButton-root R3AppBar-signinButton-6 MuiIconButton-colorInherit"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeLarge R3AppBar-signinButton-6 css-1pz7awu-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="signin-menu"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -77,25 +77,21 @@ exports[`R3AppBar test snapshot for R3AppBar 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Account"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="AccountCircleIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>

--- a/test/__tests__/__snapshots__/r3container-test.jsx.snap
+++ b/test/__tests__/__snapshots__/r3container-test.jsx.snap
@@ -3,20 +3,22 @@
 exports[`R3Container test snapshot for R3Container 1`] = `
 Array [
   <header
-    className="MuiPaper-root MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary R3AppBar-root-3 MuiPaper-elevation4"
+    className="MuiPaper-root MuiPaper-elevation MuiPaper-elevation4 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionStatic R3AppBar-root-3 css-hip9hq-MuiPaper-root-MuiAppBar-root"
   >
     <div
-      className="MuiToolbar-root MuiToolbar-regular R3AppBar-toolbar-4 MuiToolbar-gutters"
+      className="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular R3AppBar-toolbar-4 css-hyum1k-MuiToolbar-root"
     >
       <button
-        aria-describedby={null}
         aria-haspopup="true"
         aria-label="main menu"
-        className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+        aria-labelledby={null}
+        className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeLarge css-1pz7awu-MuiButtonBase-root-MuiIconButton-root"
+        data-mui-internal-clone-element={true}
         disabled={false}
         label="main-menu"
         onBlur={[Function]}
         onClick={[Function]}
+        onContextMenu={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -30,41 +32,39 @@ Array [
         onTouchMove={[Function]}
         onTouchStart={[Function]}
         tabIndex={0}
-        title="Main menu"
         type="button"
       >
-        <span
-          className="MuiIconButton-label"
+        <svg
+          aria-hidden={true}
+          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          data-testid="MenuIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
         >
-          <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"
-            />
-          </svg>
-        </span>
+          <path
+            d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"
+          />
+        </svg>
         <span
-          className="MuiTouchRipple-root"
+          className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
       </button>
       <h6
-        className="MuiTypography-root R3AppBar-title-5 MuiTypography-h6 MuiTypography-colorInherit MuiTypography-noWrap"
+        className="MuiTypography-root MuiTypography-h6 MuiTypography-noWrap R3AppBar-title-5 css-8uzb32-MuiTypography-root"
       >
         K2HR3
       </h6>
       <button
-        aria-describedby={null}
         aria-haspopup="true"
         aria-label="signin menu"
-        className="MuiButtonBase-root MuiIconButton-root R3AppBar-signinButton-8 MuiIconButton-colorInherit"
+        aria-labelledby={null}
+        className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeLarge R3AppBar-signinButton-8 css-1pz7awu-MuiButtonBase-root-MuiIconButton-root"
+        data-mui-internal-clone-element={true}
         disabled={false}
         label="signin-menu"
         onBlur={[Function]}
         onClick={[Function]}
+        onContextMenu={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -78,25 +78,21 @@ Array [
         onTouchMove={[Function]}
         onTouchStart={[Function]}
         tabIndex={0}
-        title="Account"
         type="button"
       >
-        <span
-          className="MuiIconButton-label"
+        <svg
+          aria-hidden={true}
+          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          data-testid="AccountCircleIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
         >
-          <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
-            />
-          </svg>
-        </span>
+          <path
+            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+          />
+        </svg>
         <span
-          className="MuiTouchRipple-root"
+          className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
       </button>
     </div>
@@ -107,39 +103,41 @@ Array [
     >
       <div>
         <header
-          className="MuiPaper-root MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary R3MainTree-subheaderAppbar-27 MuiPaper-elevation0"
+          className="MuiPaper-root MuiPaper-elevation MuiPaper-elevation0 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionStatic R3MainTree-subheaderAppbar-27 css-120r8wl-MuiPaper-root-MuiAppBar-root"
         >
           <div
-            className="MuiToolbar-root MuiToolbar-regular R3MainTree-subheaderToolbar-28 MuiToolbar-gutters"
+            className="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular R3MainTree-subheaderToolbar-28 css-hyum1k-MuiToolbar-root"
           >
             <div
-              className="MuiChip-root R3MainTree-chip-31 MuiChip-colorPrimary"
+              className="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-filledPrimary R3MainTree-chip-31 css-17tfht9-MuiChip-root"
               onKeyDown={[Function]}
               onKeyUp={[Function]}
             >
               <span
-                className="MuiChip-label"
+                className="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
               >
                 <span
-                  className="MuiTypography-root R3MainTree-chipText-32 MuiTypography-subtitle2"
+                  className="MuiTypography-root MuiTypography-subtitle2 R3MainTree-chipText-32 css-1sr7afs-MuiTypography-root"
                 >
                   TENANT
                 </span>
               </span>
             </div>
             <span
-              className="MuiTypography-root R3MainTree-tenantListText-24 MuiTypography-subtitle2 MuiTypography-colorTextSecondary"
+              className="MuiTypography-root MuiTypography-subtitle2 R3MainTree-tenantListText-24 css-1oowxap-MuiTypography-root"
             >
               No tenant list
             </span>
             <button
-              aria-describedby={null}
               aria-label="select tenant"
-              className="MuiButtonBase-root MuiIconButton-root"
+              aria-labelledby={null}
+              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element={true}
               disabled={false}
               label="select-tenant"
               onBlur={[Function]}
               onClick={[Function]}
+              onContextMenu={[Function]}
               onDragLeave={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -153,40 +151,36 @@ Array [
               onTouchMove={[Function]}
               onTouchStart={[Function]}
               tabIndex={0}
-              title="Select tenant"
               type="button"
             >
-              <span
-                className="MuiIconButton-label"
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="MoreVertIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
               >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
-                  />
-                </svg>
-              </span>
+                <path
+                  d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                />
+              </svg>
               <span
-                className="MuiTouchRipple-root"
+                className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
               />
             </button>
           </div>
         </header>
       </div>
       <div
-        className="MuiList-root"
+        className="MuiList-root css-1mk9mw3-MuiList-root"
         id="mainTree-top-list"
       >
         <div>
           <div
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
             onBlur={[Function]}
             onClick={[Function]}
+            onContextMenu={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -201,11 +195,12 @@ Array [
             tabIndex={0}
           >
             <div
-              className="MuiListItemIcon-root"
+              className="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
             >
               <svg
                 aria-hidden={true}
-                className="MuiSvgIcon-root"
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="LabelIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
@@ -215,25 +210,25 @@ Array [
               </svg>
             </div>
             <div
-              className="MuiListItemText-root R3MainTree-listItemText-39"
+              className="MuiListItemText-root R3MainTree-listItemText-39 css-tlelie-MuiListItemText-root"
             >
               <span
-                className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                className="MuiTypography-root MuiTypography-subtitle2 MuiListItemText-primary css-1491uh5-MuiTypography-root"
               >
                 SERVICE
               </span>
             </div>
             <span
-              className="MuiTouchRipple-root"
+              className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
             />
           </div>
         </div>
         <div>
           <div
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
             onBlur={[Function]}
             onClick={[Function]}
+            onContextMenu={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -248,11 +243,12 @@ Array [
             tabIndex={0}
           >
             <div
-              className="MuiListItemIcon-root"
+              className="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
             >
               <svg
                 aria-hidden={true}
-                className="MuiSvgIcon-root"
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="LabelIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
@@ -262,25 +258,25 @@ Array [
               </svg>
             </div>
             <div
-              className="MuiListItemText-root R3MainTree-listItemText-39"
+              className="MuiListItemText-root R3MainTree-listItemText-39 css-tlelie-MuiListItemText-root"
             >
               <span
-                className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                className="MuiTypography-root MuiTypography-subtitle2 MuiListItemText-primary css-1491uh5-MuiTypography-root"
               >
                 ROLE
               </span>
             </div>
             <span
-              className="MuiTouchRipple-root"
+              className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
             />
           </div>
         </div>
         <div>
           <div
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
             onBlur={[Function]}
             onClick={[Function]}
+            onContextMenu={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -295,11 +291,12 @@ Array [
             tabIndex={0}
           >
             <div
-              className="MuiListItemIcon-root"
+              className="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
             >
               <svg
                 aria-hidden={true}
-                className="MuiSvgIcon-root"
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="LabelIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
@@ -309,25 +306,25 @@ Array [
               </svg>
             </div>
             <div
-              className="MuiListItemText-root R3MainTree-listItemText-39"
+              className="MuiListItemText-root R3MainTree-listItemText-39 css-tlelie-MuiListItemText-root"
             >
               <span
-                className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                className="MuiTypography-root MuiTypography-subtitle2 MuiListItemText-primary css-1491uh5-MuiTypography-root"
               >
                 RESOURCE
               </span>
             </div>
             <span
-              className="MuiTouchRipple-root"
+              className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
             />
           </div>
         </div>
         <div>
           <div
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
             onBlur={[Function]}
             onClick={[Function]}
+            onContextMenu={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -342,11 +339,12 @@ Array [
             tabIndex={0}
           >
             <div
-              className="MuiListItemIcon-root"
+              className="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
             >
               <svg
                 aria-hidden={true}
-                className="MuiSvgIcon-root"
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="LabelIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
@@ -356,16 +354,16 @@ Array [
               </svg>
             </div>
             <div
-              className="MuiListItemText-root R3MainTree-listItemText-39"
+              className="MuiListItemText-root R3MainTree-listItemText-39 css-tlelie-MuiListItemText-root"
             >
               <span
-                className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                className="MuiTypography-root MuiTypography-subtitle2 MuiListItemText-primary css-1491uh5-MuiTypography-root"
               >
                 POLICY
               </span>
             </div>
             <span
-              className="MuiTouchRipple-root"
+              className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
             />
           </div>
         </div>
@@ -374,17 +372,19 @@ Array [
     <div>
       <div>
         <header
-          className="MuiPaper-root MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary R3Toolbar-root-42 MuiPaper-elevation0"
+          className="MuiPaper-root MuiPaper-elevation MuiPaper-elevation0 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionStatic R3Toolbar-root-42 css-120r8wl-MuiPaper-root-MuiAppBar-root"
         >
           <div
-            className="MuiToolbar-root MuiToolbar-regular R3Toolbar-toolbar-43 MuiToolbar-gutters"
+            className="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular R3Toolbar-toolbar-43 css-hyum1k-MuiToolbar-root"
           >
             <div
-              aria-describedby={null}
               aria-label="current display item and its path"
-              className="MuiButtonBase-root MuiChip-root R3Toolbar-chip-45 MuiChip-colorPrimary MuiChip-clickableColorPrimary MuiChip-clickable"
+              aria-labelledby={null}
+              className="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary R3Toolbar-chip-45 css-799jnf-MuiButtonBase-root-MuiChip-root"
+              data-mui-internal-clone-element={true}
               onBlur={[Function]}
               onClick={[Function]}
+              onContextMenu={[Function]}
               onDragLeave={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -399,14 +399,14 @@ Array [
               onTouchStart={[Function]}
               role="button"
               tabIndex={0}
-              title="Display path information"
             >
               <div
-                className="MuiAvatar-root MuiAvatar-circular MuiChip-avatar R3Toolbar-avatar-48 MuiChip-avatarColorPrimary MuiAvatar-colorDefault"
+                className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault R3Toolbar-avatar-48 css-2s90m6-MuiAvatar-root"
               >
                 <svg
                   aria-hidden={true}
-                  className="MuiSvgIcon-root R3Toolbar-descriptionIcon-49"
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3Toolbar-descriptionIcon-49 css-i4bv87-MuiSvgIcon-root"
+                  data-testid="DescriptionIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -416,20 +416,20 @@ Array [
                 </svg>
               </div>
               <span
-                className="MuiChip-label"
+                className="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
               >
                 <span
-                  className="MuiTypography-root R3Toolbar-chipText-46 MuiTypography-subtitle2"
+                  className="MuiTypography-root MuiTypography-subtitle2 R3Toolbar-chipText-46 css-1sr7afs-MuiTypography-root"
                 >
                   Unselected
                 </span>
               </span>
               <span
-                className="MuiTouchRipple-root"
+                className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
               />
             </div>
             <span
-              className="MuiTypography-root R3Toolbar-title-44 MuiTypography-subtitle2 MuiTypography-colorTextSecondary MuiTypography-noWrap"
+              className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3Toolbar-title-44 css-k76d41-MuiTypography-root"
             >
               
             </span>
@@ -440,11 +440,12 @@ Array [
         </header>
       </div>
       <div
-        className="MuiPaper-root R3MsgBox-root-141 MuiPaper-elevation2 MuiPaper-rounded"
+        className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 R3MsgBox-root-141 css-1mbunh-MuiPaper-root"
       >
         <svg
           aria-hidden={true}
-          className="MuiSvgIcon-root R3MsgBox-informationIcon-147"
+          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3MsgBox-informationIcon-147 css-i4bv87-MuiSvgIcon-root"
+          data-testid="InfoOutlinedIcon"
           focusable="false"
           viewBox="0 0 24 24"
         >
@@ -453,7 +454,7 @@ Array [
           />
         </svg>
         <span
-          className="MuiTypography-root R3MsgBox-dialogInformationContentText-144 MuiTypography-body1"
+          className="MuiTypography-root MuiTypography-body1 R3MsgBox-dialogInformationContentText-144 css-10hburv-MuiTypography-root"
         >
           First select the tenant, then select ROLE / RESOURCE / POLICY, then browse and edit.
           <br />

--- a/test/__tests__/__snapshots__/r3createpathdialog-test.jsx.snap
+++ b/test/__tests__/__snapshots__/r3createpathdialog-test.jsx.snap
@@ -2,341 +2,66 @@
 
 exports[`R3CreatePathDialog test snapshot for R3CreatePathDialog 1`] = `
 <
-  BackdropComponent={
-    Object {
-      "$$typeof": Symbol(react.forward_ref),
-      "Naked": Object {
-        "$$typeof": Symbol(react.forward_ref),
-        "propTypes": Object {
-          "children": [Function],
-          "className": [Function],
-          "classes": [Function],
-          "invisible": [Function],
-          "open": [Function],
-          "transitionDuration": [Function],
-        },
-        "render": [Function],
-      },
-      "options": Object {
-        "defaultTheme": Object {
-          "breakpoints": Object {
-            "between": [Function],
-            "down": [Function],
-            "keys": Array [
-              "xs",
-              "sm",
-              "md",
-              "lg",
-              "xl",
-            ],
-            "only": [Function],
-            "up": [Function],
-            "values": Object {
-              "lg": 1280,
-              "md": 960,
-              "sm": 600,
-              "xl": 1920,
-              "xs": 0,
-            },
-            "width": [Function],
-          },
-          "direction": "ltr",
-          "mixins": Object {
-            "gutters": [Function],
-            "toolbar": Object {
-              "@media (min-width:0px) and (orientation: landscape)": Object {
-                "minHeight": 48,
-              },
-              "@media (min-width:600px)": Object {
-                "minHeight": 64,
-              },
-              "minHeight": 56,
-            },
-          },
-          "overrides": Object {},
-          "palette": Object {
-            "action": Object {
-              "activatedOpacity": 0.12,
-              "active": "rgba(0, 0, 0, 0.54)",
-              "disabled": "rgba(0, 0, 0, 0.26)",
-              "disabledBackground": "rgba(0, 0, 0, 0.12)",
-              "disabledOpacity": 0.38,
-              "focus": "rgba(0, 0, 0, 0.12)",
-              "focusOpacity": 0.12,
-              "hover": "rgba(0, 0, 0, 0.04)",
-              "hoverOpacity": 0.04,
-              "selected": "rgba(0, 0, 0, 0.08)",
-              "selectedOpacity": 0.08,
-            },
-            "augmentColor": [Function],
-            "background": Object {
-              "default": "#fafafa",
-              "paper": "#fff",
-            },
-            "common": Object {
-              "black": "#000",
-              "white": "#fff",
-            },
-            "contrastThreshold": 3,
-            "divider": "rgba(0, 0, 0, 0.12)",
-            "error": Object {
-              "contrastText": "#fff",
-              "dark": "#d32f2f",
-              "light": "#e57373",
-              "main": "#f44336",
-            },
-            "getContrastText": [Function],
-            "grey": Object {
-              "100": "#f5f5f5",
-              "200": "#eeeeee",
-              "300": "#e0e0e0",
-              "400": "#bdbdbd",
-              "50": "#fafafa",
-              "500": "#9e9e9e",
-              "600": "#757575",
-              "700": "#616161",
-              "800": "#424242",
-              "900": "#212121",
-              "A100": "#d5d5d5",
-              "A200": "#aaaaaa",
-              "A400": "#303030",
-              "A700": "#616161",
-            },
-            "info": Object {
-              "contrastText": "#fff",
-              "dark": "#1976d2",
-              "light": "#64b5f6",
-              "main": "#2196f3",
-            },
-            "primary": Object {
-              "contrastText": "#fff",
-              "dark": "#303f9f",
-              "light": "#7986cb",
-              "main": "#3f51b5",
-            },
-            "secondary": Object {
-              "contrastText": "#fff",
-              "dark": "#c51162",
-              "light": "#ff4081",
-              "main": "#f50057",
-            },
-            "success": Object {
-              "contrastText": "rgba(0, 0, 0, 0.87)",
-              "dark": "#388e3c",
-              "light": "#81c784",
-              "main": "#4caf50",
-            },
-            "text": Object {
-              "disabled": "rgba(0, 0, 0, 0.38)",
-              "hint": "rgba(0, 0, 0, 0.38)",
-              "primary": "rgba(0, 0, 0, 0.87)",
-              "secondary": "rgba(0, 0, 0, 0.54)",
-            },
-            "tonalOffset": 0.2,
-            "type": "light",
-            "warning": Object {
-              "contrastText": "rgba(0, 0, 0, 0.87)",
-              "dark": "#f57c00",
-              "light": "#ffb74d",
-              "main": "#ff9800",
-            },
-          },
-          "props": Object {},
-          "shadows": Array [
-            "none",
-            "0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
-            "0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)",
-            "0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)",
-            "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
-            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
-            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
-            "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
-            "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
-            "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
-            "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
-            "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
-            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
-            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
-            "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
-            "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
-            "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
-            "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
-            "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
-            "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
-            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
-            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
-            "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
-            "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
-            "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
-          ],
-          "shape": Object {
-            "borderRadius": 4,
-          },
-          "spacing": [Function],
-          "transitions": Object {
-            "create": [Function],
-            "duration": Object {
-              "complex": 375,
-              "enteringScreen": 225,
-              "leavingScreen": 195,
-              "short": 250,
-              "shorter": 200,
-              "shortest": 150,
-              "standard": 300,
-            },
-            "easing": Object {
-              "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
-              "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
-              "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
-              "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
-            },
-            "getAutoHeightDuration": [Function],
-          },
-          "typography": Object {
-            "body1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00938em",
-              "lineHeight": 1.5,
-            },
-            "body2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.01071em",
-              "lineHeight": 1.43,
-            },
-            "button": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.02857em",
-              "lineHeight": 1.75,
-              "textTransform": "uppercase",
-            },
-            "caption": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.75rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.03333em",
-              "lineHeight": 1.66,
-            },
-            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-            "fontSize": 14,
-            "fontWeightBold": 700,
-            "fontWeightLight": 300,
-            "fontWeightMedium": 500,
-            "fontWeightRegular": 400,
-            "h1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "6rem",
-              "fontWeight": 300,
-              "letterSpacing": "-0.01562em",
-              "lineHeight": 1.167,
-            },
-            "h2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "3.75rem",
-              "fontWeight": 300,
-              "letterSpacing": "-0.00833em",
-              "lineHeight": 1.2,
-            },
-            "h3": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "3rem",
-              "fontWeight": 400,
-              "letterSpacing": "0em",
-              "lineHeight": 1.167,
-            },
-            "h4": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "2.125rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00735em",
-              "lineHeight": 1.235,
-            },
-            "h5": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1.5rem",
-              "fontWeight": 400,
-              "letterSpacing": "0em",
-              "lineHeight": 1.334,
-            },
-            "h6": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1.25rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.0075em",
-              "lineHeight": 1.6,
-            },
-            "htmlFontSize": 16,
-            "overline": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.75rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.08333em",
-              "lineHeight": 2.66,
-              "textTransform": "uppercase",
-            },
-            "pxToRem": [Function],
-            "round": [Function],
-            "subtitle1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00938em",
-              "lineHeight": 1.75,
-            },
-            "subtitle2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.00714em",
-              "lineHeight": 1.57,
-            },
-          },
-          "zIndex": Object {
-            "appBar": 1100,
-            "drawer": 1200,
-            "mobileStepper": 1000,
-            "modal": 1300,
-            "snackbar": 1400,
-            "speedDial": 1050,
-            "tooltip": 1500,
-          },
-        },
-        "name": "MuiBackdrop",
-      },
-      "propTypes": Object {
-        "classes": [Function],
-        "innerRef": [Function],
-      },
-      "render": [Function],
-      "useStyles": [Function],
-    }
-  }
-  BackdropProps={
-    Object {
-      "transitionDuration": Object {
-        "enter": 225,
-        "exit": 195,
-      },
-    }
-  }
   aria-label="create path dialog"
-  className="MuiDialog-root R3CreatePathDialog-root-1"
+  className="MuiDialog-root R3CreatePathDialog-root-1 css-1h8td7x-MuiDialog-root"
   closeAfterTransition={true}
+  components={
+    Object {
+      "Backdrop": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "__emotion_base": Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "propTypes": Object {
+            "children": [Function],
+            "className": [Function],
+            "classes": [Function],
+            "component": [Function],
+            "components": [Function],
+            "componentsProps": [Function],
+            "invisible": [Function],
+            "open": [Function],
+            "sx": [Function],
+            "transitionDuration": [Function],
+          },
+          "render": [Function],
+        },
+        "__emotion_forwardProp": [Function],
+        "__emotion_real": [Circular],
+        "__emotion_styles": Array [
+          "label:MuiDialog-backdrop;",
+          Object {
+            "zIndex": -1,
+          },
+          [Function],
+        ],
+        "defaultProps": undefined,
+        "render": [Function],
+        "withComponent": [Function],
+      },
+    }
+  }
+  componentsProps={
+    Object {
+      "backdrop": Object {
+        "as": undefined,
+        "transitionDuration": Object {
+          "enter": 225,
+          "exit": 195,
+        },
+      },
+    }
+  }
   disableEscapeKeyDown={false}
   disablePortal={true}
   label="create-path-dialog"
+  onClick={[Function]}
   onClose={[Function]}
   open={true}
 >
   <
     appear={true}
     in={true}
-    role="none presentation"
+    role="presentation"
     timeout={
       Object {
         "enter": 225,
@@ -345,78 +70,73 @@ exports[`R3CreatePathDialog test snapshot for R3CreatePathDialog 1`] = `
     }
   >
     <div
-      className="MuiDialog-container MuiDialog-scrollBody"
+      className="MuiDialog-container MuiDialog-scrollBody css-iz3z40-MuiDialog-container"
       onMouseDown={[Function]}
-      onMouseUp={[Function]}
     >
       <div
-        className="MuiPaper-root MuiDialog-paper MuiDialog-paperScrollBody MuiDialog-paperWidthSm MuiDialog-paperFullWidth MuiPaper-elevation24 MuiPaper-rounded"
+        className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollBody MuiDialog-paperWidthSm MuiDialog-paperFullWidth css-zfoovh-MuiPaper-root-MuiDialog-paper"
         role="dialog"
       >
-        <div
-          className="MuiDialogTitle-root R3CreatePathDialog-dialogTitle-2"
+        <h2
+          className="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root R3CreatePathDialog-dialogTitle-2 css-bdhsul-MuiTypography-root-MuiDialogTitle-root"
           label="create-path-dialog"
         >
-          <h2
-            className="MuiTypography-root MuiTypography-h6"
+          <span
+            className="MuiTypography-root MuiTypography-h5 MuiTypography-noWrap R3CreatePathDialog-title-3 css-idtq1y-MuiTypography-root"
           >
-            <span
-              className="MuiTypography-root R3CreatePathDialog-title-3 MuiTypography-h5 MuiTypography-colorPrimary MuiTypography-noWrap"
-            >
-              Create a new path
-            </span>
-          </h2>
-        </div>
+            Create a new path
+          </span>
+        </h2>
         <div
-          className="MuiDialogContent-root R3CreatePathDialog-dialogContent-4"
+          className="MuiDialogContent-root R3CreatePathDialog-dialogContent-4 css-ypiqx9-MuiDialogContent-root"
         >
           <span
-            className="MuiTypography-root R3CreatePathDialog-keyTitle-5 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3CreatePathDialog-keyTitle-5 css-qxncr6-MuiTypography-root"
           >
             TENANT
           </span>
           <span
-            className="MuiTypography-root R3CreatePathDialog-value-6 MuiTypography-body1 MuiTypography-colorTextSecondary"
+            className="MuiTypography-root MuiTypography-body1 R3CreatePathDialog-value-6 css-nrdprl-MuiTypography-root"
           >
             GROUP0:TENANT0
           </span>
           <span
-            className="MuiTypography-root R3CreatePathDialog-keyTitle-5 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3CreatePathDialog-keyTitle-5 css-qxncr6-MuiTypography-root"
           >
             TYPE
           </span>
           <span
-            className="MuiTypography-root R3CreatePathDialog-value-6 MuiTypography-body1 MuiTypography-colorTextSecondary"
+            className="MuiTypography-root MuiTypography-body1 R3CreatePathDialog-value-6 css-nrdprl-MuiTypography-root"
           >
             role
           </span>
           <span
-            className="MuiTypography-root R3CreatePathDialog-keyTitle-5 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3CreatePathDialog-keyTitle-5 css-qxncr6-MuiTypography-root"
           >
             PARENT PATH
           </span>
           <span
-            className="MuiTypography-root R3CreatePathDialog-value-6 MuiTypography-body1 MuiTypography-colorTextSecondary"
+            className="MuiTypography-root MuiTypography-body1 R3CreatePathDialog-value-6 css-nrdprl-MuiTypography-root"
           >
             /JEST_ROLE_PARENT_PATH
           </span>
           <span
-            className="MuiTypography-root R3CreatePathDialog-keyTitle-5 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3CreatePathDialog-keyTitle-5 css-qxncr6-MuiTypography-root"
           >
             CREATE PATH
           </span>
           <div
-            className="MuiFormControl-root MuiTextField-root R3CreatePathDialog-textField-8"
+            className="MuiFormControl-root MuiTextField-root R3CreatePathDialog-textField-8 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
           >
             <div
-              className="MuiInputBase-root MuiInput-root MuiInput-underline R3CreatePathDialog-inputTextField-9 MuiInputBase-formControl MuiInput-formControl"
+              className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3CreatePathDialog-inputTextField-9 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
               onClick={[Function]}
             >
               <input
                 aria-invalid={false}
                 aria-label="input create path"
                 autoFocus={false}
-                className="MuiInputBase-input MuiInput-input"
+                className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
                 disabled={false}
                 id="new-path-textfield-id"
                 onAnimationStart={[Function]}
@@ -432,14 +152,15 @@ exports[`R3CreatePathDialog test snapshot for R3CreatePathDialog 1`] = `
           </div>
         </div>
         <div
-          className="MuiDialogActions-root MuiDialogActions-spacing"
+          className="MuiDialogActions-root MuiDialogActions-spacing css-hlj6pa-MuiDialogActions-root"
         >
           <button
             aria-label="cancel"
-            className="MuiButtonBase-root MuiButton-root MuiButton-contained R3CreatePathDialog-cancelButton-10 MuiButton-containedPrimary"
+            className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root R3CreatePathDialog-cancelButton-10 css-sghohy-MuiButtonBase-root-MuiButton-root"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
+            onContextMenu={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -453,28 +174,26 @@ exports[`R3CreatePathDialog test snapshot for R3CreatePathDialog 1`] = `
             tabIndex={0}
             type="button"
           >
-            <span
-              className="MuiButton-label"
+            CANCEL
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3CreatePathDialog-buttonIcon-12 css-i4bv87-MuiSvgIcon-root"
+              data-testid="CancelIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              CANCEL
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root R3CreatePathDialog-buttonIcon-12"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
-                />
-              </svg>
-            </span>
+              <path
+                d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+              />
+            </svg>
           </button>
           <button
             aria-label="ok"
-            className="MuiButtonBase-root MuiButton-root MuiButton-contained R3CreatePathDialog-okButton-11 MuiButton-containedSecondary Mui-disabled Mui-disabled"
+            className="MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root Mui-disabled R3CreatePathDialog-okButton-11 css-zcbmsk-MuiButtonBase-root-MuiButton-root"
             disabled={true}
             onBlur={[Function]}
             onClick={[Function]}
+            onContextMenu={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -488,21 +207,18 @@ exports[`R3CreatePathDialog test snapshot for R3CreatePathDialog 1`] = `
             tabIndex={-1}
             type="button"
           >
-            <span
-              className="MuiButton-label"
+            OK
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3CreatePathDialog-buttonIcon-12 css-i4bv87-MuiSvgIcon-root"
+              data-testid="CheckCircleIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              OK
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root R3CreatePathDialog-buttonIcon-12"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                />
-              </svg>
-            </span>
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+              />
+            </svg>
           </button>
         </div>
       </div>

--- a/test/__tests__/__snapshots__/r3createservicedialog-test.jsx.snap
+++ b/test/__tests__/__snapshots__/r3createservicedialog-test.jsx.snap
@@ -2,341 +2,66 @@
 
 exports[`R3CreateServiceDialog test snapshot for R3CreateServiceDialog 1`] = `
 <
-  BackdropComponent={
-    Object {
-      "$$typeof": Symbol(react.forward_ref),
-      "Naked": Object {
-        "$$typeof": Symbol(react.forward_ref),
-        "propTypes": Object {
-          "children": [Function],
-          "className": [Function],
-          "classes": [Function],
-          "invisible": [Function],
-          "open": [Function],
-          "transitionDuration": [Function],
-        },
-        "render": [Function],
-      },
-      "options": Object {
-        "defaultTheme": Object {
-          "breakpoints": Object {
-            "between": [Function],
-            "down": [Function],
-            "keys": Array [
-              "xs",
-              "sm",
-              "md",
-              "lg",
-              "xl",
-            ],
-            "only": [Function],
-            "up": [Function],
-            "values": Object {
-              "lg": 1280,
-              "md": 960,
-              "sm": 600,
-              "xl": 1920,
-              "xs": 0,
-            },
-            "width": [Function],
-          },
-          "direction": "ltr",
-          "mixins": Object {
-            "gutters": [Function],
-            "toolbar": Object {
-              "@media (min-width:0px) and (orientation: landscape)": Object {
-                "minHeight": 48,
-              },
-              "@media (min-width:600px)": Object {
-                "minHeight": 64,
-              },
-              "minHeight": 56,
-            },
-          },
-          "overrides": Object {},
-          "palette": Object {
-            "action": Object {
-              "activatedOpacity": 0.12,
-              "active": "rgba(0, 0, 0, 0.54)",
-              "disabled": "rgba(0, 0, 0, 0.26)",
-              "disabledBackground": "rgba(0, 0, 0, 0.12)",
-              "disabledOpacity": 0.38,
-              "focus": "rgba(0, 0, 0, 0.12)",
-              "focusOpacity": 0.12,
-              "hover": "rgba(0, 0, 0, 0.04)",
-              "hoverOpacity": 0.04,
-              "selected": "rgba(0, 0, 0, 0.08)",
-              "selectedOpacity": 0.08,
-            },
-            "augmentColor": [Function],
-            "background": Object {
-              "default": "#fafafa",
-              "paper": "#fff",
-            },
-            "common": Object {
-              "black": "#000",
-              "white": "#fff",
-            },
-            "contrastThreshold": 3,
-            "divider": "rgba(0, 0, 0, 0.12)",
-            "error": Object {
-              "contrastText": "#fff",
-              "dark": "#d32f2f",
-              "light": "#e57373",
-              "main": "#f44336",
-            },
-            "getContrastText": [Function],
-            "grey": Object {
-              "100": "#f5f5f5",
-              "200": "#eeeeee",
-              "300": "#e0e0e0",
-              "400": "#bdbdbd",
-              "50": "#fafafa",
-              "500": "#9e9e9e",
-              "600": "#757575",
-              "700": "#616161",
-              "800": "#424242",
-              "900": "#212121",
-              "A100": "#d5d5d5",
-              "A200": "#aaaaaa",
-              "A400": "#303030",
-              "A700": "#616161",
-            },
-            "info": Object {
-              "contrastText": "#fff",
-              "dark": "#1976d2",
-              "light": "#64b5f6",
-              "main": "#2196f3",
-            },
-            "primary": Object {
-              "contrastText": "#fff",
-              "dark": "#303f9f",
-              "light": "#7986cb",
-              "main": "#3f51b5",
-            },
-            "secondary": Object {
-              "contrastText": "#fff",
-              "dark": "#c51162",
-              "light": "#ff4081",
-              "main": "#f50057",
-            },
-            "success": Object {
-              "contrastText": "rgba(0, 0, 0, 0.87)",
-              "dark": "#388e3c",
-              "light": "#81c784",
-              "main": "#4caf50",
-            },
-            "text": Object {
-              "disabled": "rgba(0, 0, 0, 0.38)",
-              "hint": "rgba(0, 0, 0, 0.38)",
-              "primary": "rgba(0, 0, 0, 0.87)",
-              "secondary": "rgba(0, 0, 0, 0.54)",
-            },
-            "tonalOffset": 0.2,
-            "type": "light",
-            "warning": Object {
-              "contrastText": "rgba(0, 0, 0, 0.87)",
-              "dark": "#f57c00",
-              "light": "#ffb74d",
-              "main": "#ff9800",
-            },
-          },
-          "props": Object {},
-          "shadows": Array [
-            "none",
-            "0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
-            "0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)",
-            "0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)",
-            "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
-            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
-            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
-            "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
-            "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
-            "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
-            "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
-            "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
-            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
-            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
-            "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
-            "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
-            "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
-            "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
-            "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
-            "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
-            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
-            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
-            "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
-            "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
-            "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
-          ],
-          "shape": Object {
-            "borderRadius": 4,
-          },
-          "spacing": [Function],
-          "transitions": Object {
-            "create": [Function],
-            "duration": Object {
-              "complex": 375,
-              "enteringScreen": 225,
-              "leavingScreen": 195,
-              "short": 250,
-              "shorter": 200,
-              "shortest": 150,
-              "standard": 300,
-            },
-            "easing": Object {
-              "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
-              "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
-              "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
-              "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
-            },
-            "getAutoHeightDuration": [Function],
-          },
-          "typography": Object {
-            "body1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00938em",
-              "lineHeight": 1.5,
-            },
-            "body2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.01071em",
-              "lineHeight": 1.43,
-            },
-            "button": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.02857em",
-              "lineHeight": 1.75,
-              "textTransform": "uppercase",
-            },
-            "caption": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.75rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.03333em",
-              "lineHeight": 1.66,
-            },
-            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-            "fontSize": 14,
-            "fontWeightBold": 700,
-            "fontWeightLight": 300,
-            "fontWeightMedium": 500,
-            "fontWeightRegular": 400,
-            "h1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "6rem",
-              "fontWeight": 300,
-              "letterSpacing": "-0.01562em",
-              "lineHeight": 1.167,
-            },
-            "h2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "3.75rem",
-              "fontWeight": 300,
-              "letterSpacing": "-0.00833em",
-              "lineHeight": 1.2,
-            },
-            "h3": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "3rem",
-              "fontWeight": 400,
-              "letterSpacing": "0em",
-              "lineHeight": 1.167,
-            },
-            "h4": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "2.125rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00735em",
-              "lineHeight": 1.235,
-            },
-            "h5": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1.5rem",
-              "fontWeight": 400,
-              "letterSpacing": "0em",
-              "lineHeight": 1.334,
-            },
-            "h6": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1.25rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.0075em",
-              "lineHeight": 1.6,
-            },
-            "htmlFontSize": 16,
-            "overline": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.75rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.08333em",
-              "lineHeight": 2.66,
-              "textTransform": "uppercase",
-            },
-            "pxToRem": [Function],
-            "round": [Function],
-            "subtitle1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00938em",
-              "lineHeight": 1.75,
-            },
-            "subtitle2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.00714em",
-              "lineHeight": 1.57,
-            },
-          },
-          "zIndex": Object {
-            "appBar": 1100,
-            "drawer": 1200,
-            "mobileStepper": 1000,
-            "modal": 1300,
-            "snackbar": 1400,
-            "speedDial": 1050,
-            "tooltip": 1500,
-          },
-        },
-        "name": "MuiBackdrop",
-      },
-      "propTypes": Object {
-        "classes": [Function],
-        "innerRef": [Function],
-      },
-      "render": [Function],
-      "useStyles": [Function],
-    }
-  }
-  BackdropProps={
-    Object {
-      "transitionDuration": Object {
-        "enter": 225,
-        "exit": 195,
-      },
-    }
-  }
   aria-label="create service dialog"
-  className="MuiDialog-root R3CreateServiceDialog-root-1"
+  className="MuiDialog-root R3CreateServiceDialog-root-1 css-1h8td7x-MuiDialog-root"
   closeAfterTransition={true}
+  components={
+    Object {
+      "Backdrop": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "__emotion_base": Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "propTypes": Object {
+            "children": [Function],
+            "className": [Function],
+            "classes": [Function],
+            "component": [Function],
+            "components": [Function],
+            "componentsProps": [Function],
+            "invisible": [Function],
+            "open": [Function],
+            "sx": [Function],
+            "transitionDuration": [Function],
+          },
+          "render": [Function],
+        },
+        "__emotion_forwardProp": [Function],
+        "__emotion_real": [Circular],
+        "__emotion_styles": Array [
+          "label:MuiDialog-backdrop;",
+          Object {
+            "zIndex": -1,
+          },
+          [Function],
+        ],
+        "defaultProps": undefined,
+        "render": [Function],
+        "withComponent": [Function],
+      },
+    }
+  }
+  componentsProps={
+    Object {
+      "backdrop": Object {
+        "as": undefined,
+        "transitionDuration": Object {
+          "enter": 225,
+          "exit": 195,
+        },
+      },
+    }
+  }
   disableEscapeKeyDown={false}
   disablePortal={true}
   label="create-service-dialog"
+  onClick={[Function]}
   onClose={[Function]}
   open={true}
 >
   <
     appear={true}
     in={true}
-    role="none presentation"
+    role="presentation"
     timeout={
       Object {
         "enter": 225,
@@ -345,57 +70,52 @@ exports[`R3CreateServiceDialog test snapshot for R3CreateServiceDialog 1`] = `
     }
   >
     <div
-      className="MuiDialog-container MuiDialog-scrollBody"
+      className="MuiDialog-container MuiDialog-scrollBody css-iz3z40-MuiDialog-container"
       onMouseDown={[Function]}
-      onMouseUp={[Function]}
     >
       <div
-        className="MuiPaper-root MuiDialog-paper MuiDialog-paperScrollBody MuiDialog-paperWidthSm MuiDialog-paperFullWidth MuiPaper-elevation24 MuiPaper-rounded"
+        className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollBody MuiDialog-paperWidthSm MuiDialog-paperFullWidth css-zfoovh-MuiPaper-root-MuiDialog-paper"
         role="dialog"
       >
-        <div
-          className="MuiDialogTitle-root R3CreateServiceDialog-dialogTitle-2"
+        <h2
+          className="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root R3CreateServiceDialog-dialogTitle-2 css-bdhsul-MuiTypography-root-MuiDialogTitle-root"
           label="create-service-dialog"
         >
-          <h2
-            className="MuiTypography-root MuiTypography-h6"
+          <span
+            className="MuiTypography-root MuiTypography-h5 MuiTypography-noWrap R3CreateServiceDialog-title-3 css-idtq1y-MuiTypography-root"
           >
-            <span
-              className="MuiTypography-root R3CreateServiceDialog-title-3 MuiTypography-h5 MuiTypography-colorPrimary MuiTypography-noWrap"
-            >
-              Create a new SERVICE
-            </span>
-          </h2>
-        </div>
+            Create a new SERVICE
+          </span>
+        </h2>
         <div
-          className="MuiDialogContent-root R3CreateServiceDialog-dialogContent-4"
+          className="MuiDialogContent-root R3CreateServiceDialog-dialogContent-4 css-ypiqx9-MuiDialogContent-root"
         >
           <span
-            className="MuiTypography-root R3CreateServiceDialog-keyTitle-5 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3CreateServiceDialog-keyTitle-5 css-qxncr6-MuiTypography-root"
           >
             TENANT for SERVICE owner
           </span>
           <span
-            className="MuiTypography-root R3CreateServiceDialog-value-6 MuiTypography-body1 MuiTypography-colorTextSecondary"
+            className="MuiTypography-root MuiTypography-body1 R3CreateServiceDialog-value-6 css-nrdprl-MuiTypography-root"
           >
             GROUP0:TENANT0
           </span>
           <span
-            className="MuiTypography-root R3CreateServiceDialog-keyTitle-5 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3CreateServiceDialog-keyTitle-5 css-qxncr6-MuiTypography-root"
           >
             CREATE SERVICE
           </span>
           <div
-            className="MuiFormControl-root MuiTextField-root R3CreateServiceDialog-textField-8"
+            className="MuiFormControl-root MuiTextField-root R3CreateServiceDialog-textField-8 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
           >
             <div
-              className="MuiInputBase-root MuiInput-root MuiInput-underline R3CreateServiceDialog-inputTextField-9 MuiInputBase-formControl MuiInput-formControl"
+              className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3CreateServiceDialog-inputTextField-9 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
               onClick={[Function]}
             >
               <input
                 aria-invalid={false}
                 autoFocus={false}
-                className="MuiInputBase-input MuiInput-input"
+                className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
                 disabled={false}
                 id="new-service-textfield-id"
                 onAnimationStart={[Function]}
@@ -410,23 +130,23 @@ exports[`R3CreateServiceDialog test snapshot for R3CreateServiceDialog 1`] = `
             </div>
           </div>
           <span
-            className="MuiTypography-root R3CreateServiceDialog-keyTitle-5 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3CreateServiceDialog-keyTitle-5 css-qxncr6-MuiTypography-root"
           >
             SERVICE RESOURCES
           </span>
           <div
             aria-label="select type verify url or static resource"
-            className="MuiFormGroup-root R3CreateServiceDialog-valueRadioGroup-11"
+            className="MuiFormGroup-root R3CreateServiceDialog-valueRadioGroup-11 css-dmmspl-MuiFormGroup-root"
             id="new-service-radiogroup-id"
             role="radiogroup"
           >
             <label
-              className="MuiFormControlLabel-root R3CreateServiceDialog-valueLeftFormControlLabel-12"
+              className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd R3CreateServiceDialog-valueLeftFormControlLabel-12 css-j204z7-MuiFormControlLabel-root"
             >
               <span
-                aria-disabled={false}
-                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-30 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-31 Mui-checked MuiIconButton-colorSecondary"
+                className="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked css-vqmohf-MuiButtonBase-root-MuiRadio-root"
                 onBlur={[Function]}
+                onContextMenu={[Function]}
                 onDragLeave={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -439,60 +159,54 @@ exports[`R3CreateServiceDialog test snapshot for R3CreateServiceDialog 1`] = `
                 onTouchStart={[Function]}
                 tabIndex={null}
               >
+                <input
+                  checked={true}
+                  className="PrivateSwitchBase-input css-1m9pwf3"
+                  disabled={false}
+                  onChange={[Function]}
+                  type="radio"
+                  value="verifyUrl"
+                />
                 <span
-                  className="MuiIconButton-label"
+                  className="css-hyxlzm"
                 >
-                  <input
-                    checked={true}
-                    className="PrivateSwitchBase-input-33"
-                    disabled={false}
-                    onChange={[Function]}
-                    type="radio"
-                    value="verifyUrl"
-                  />
-                  <div
-                    className="PrivateRadioButtonIcon-root-34 PrivateRadioButtonIcon-checked-36"
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hbvpl3-MuiSvgIcon-root"
+                    data-testid="RadioButtonUncheckedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-35"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                      />
-                    </svg>
-                  </div>
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                    />
+                  </svg>
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-11zohuh-MuiSvgIcon-root"
+                    data-testid="RadioButtonCheckedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                    />
+                  </svg>
                 </span>
               </span>
-              <span
-                className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+              <p
+                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-7podw6-MuiTypography-root"
               >
-                <p
-                  className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary MuiTypography-noWrap"
-                >
-                  VERIFY URL
-                </p>
-              </span>
+                VERIFY URL
+              </p>
             </label>
             <label
-              className="MuiFormControlLabel-root R3CreateServiceDialog-valueRightFormControlLabel-13"
+              className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd R3CreateServiceDialog-valueRightFormControlLabel-13 css-j204z7-MuiFormControlLabel-root"
             >
               <span
-                aria-disabled={false}
-                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-30 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+                className="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root css-vqmohf-MuiButtonBase-root-MuiRadio-root"
                 onBlur={[Function]}
+                onContextMenu={[Function]}
                 onDragLeave={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -505,65 +219,59 @@ exports[`R3CreateServiceDialog test snapshot for R3CreateServiceDialog 1`] = `
                 onTouchStart={[Function]}
                 tabIndex={null}
               >
+                <input
+                  checked={false}
+                  className="PrivateSwitchBase-input css-1m9pwf3"
+                  disabled={false}
+                  onChange={[Function]}
+                  type="radio"
+                  value="staticResourceObject"
+                />
                 <span
-                  className="MuiIconButton-label"
+                  className="css-hyxlzm"
                 >
-                  <input
-                    checked={false}
-                    className="PrivateSwitchBase-input-33"
-                    disabled={false}
-                    onChange={[Function]}
-                    type="radio"
-                    value="staticResourceObject"
-                  />
-                  <div
-                    className="PrivateRadioButtonIcon-root-34"
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hbvpl3-MuiSvgIcon-root"
+                    data-testid="RadioButtonUncheckedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-35"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                      />
-                    </svg>
-                  </div>
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                    />
+                  </svg>
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hhw7if-MuiSvgIcon-root"
+                    data-testid="RadioButtonCheckedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                    />
+                  </svg>
                 </span>
               </span>
-              <span
-                className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+              <p
+                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-7podw6-MuiTypography-root"
               >
-                <p
-                  className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary MuiTypography-noWrap"
-                >
-                  STATIC RESOURCE OBJECT
-                </p>
-              </span>
+                STATIC RESOURCE OBJECT
+              </p>
             </label>
           </div>
           <div
-            className="MuiFormControl-root MuiTextField-root R3CreateServiceDialog-textField-8"
+            className="MuiFormControl-root MuiTextField-root R3CreateServiceDialog-textField-8 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
           >
             <div
-              className="MuiInputBase-root MuiInput-root MuiInput-underline R3CreateServiceDialog-inputTextField-9 MuiInputBase-formControl MuiInput-formControl"
+              className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3CreateServiceDialog-inputTextField-9 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
               onClick={[Function]}
             >
               <input
                 aria-invalid={false}
                 autoFocus={false}
-                className="MuiInputBase-input MuiInput-input"
+                className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
                 disabled={false}
                 id="new-verify-textfield-id"
                 onAnimationStart={[Function]}
@@ -579,14 +287,15 @@ exports[`R3CreateServiceDialog test snapshot for R3CreateServiceDialog 1`] = `
           </div>
         </div>
         <div
-          className="MuiDialogActions-root MuiDialogActions-spacing"
+          className="MuiDialogActions-root MuiDialogActions-spacing css-hlj6pa-MuiDialogActions-root"
         >
           <button
             aria-label="cancel"
-            className="MuiButtonBase-root MuiButton-root MuiButton-contained R3CreateServiceDialog-cancelButton-27 MuiButton-containedPrimary"
+            className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root R3CreateServiceDialog-cancelButton-27 css-sghohy-MuiButtonBase-root-MuiButton-root"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
+            onContextMenu={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -600,28 +309,26 @@ exports[`R3CreateServiceDialog test snapshot for R3CreateServiceDialog 1`] = `
             tabIndex={0}
             type="button"
           >
-            <span
-              className="MuiButton-label"
+            CANCEL
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3CreateServiceDialog-buttonIcon-29 css-i4bv87-MuiSvgIcon-root"
+              data-testid="CancelIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              CANCEL
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root R3CreateServiceDialog-buttonIcon-29"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
-                />
-              </svg>
-            </span>
+              <path
+                d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+              />
+            </svg>
           </button>
           <button
             aria-label="ok"
-            className="MuiButtonBase-root MuiButton-root MuiButton-contained R3CreateServiceDialog-okButton-28 MuiButton-containedSecondary Mui-disabled Mui-disabled"
+            className="MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root Mui-disabled R3CreateServiceDialog-okButton-28 css-zcbmsk-MuiButtonBase-root-MuiButton-root"
             disabled={true}
             onBlur={[Function]}
             onClick={[Function]}
+            onContextMenu={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -635,21 +342,18 @@ exports[`R3CreateServiceDialog test snapshot for R3CreateServiceDialog 1`] = `
             tabIndex={-1}
             type="button"
           >
-            <span
-              className="MuiButton-label"
+            OK
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3CreateServiceDialog-buttonIcon-29 css-i4bv87-MuiSvgIcon-root"
+              data-testid="CheckCircleIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              OK
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root R3CreateServiceDialog-buttonIcon-29"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                />
-              </svg>
-            </span>
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+              />
+            </svg>
           </button>
         </div>
       </div>

--- a/test/__tests__/__snapshots__/r3createservicetenantdialog-test.jsx.snap
+++ b/test/__tests__/__snapshots__/r3createservicetenantdialog-test.jsx.snap
@@ -2,340 +2,65 @@
 
 exports[`R3CreateServiceTenantDialog test snapshot for R3CreateServiceTenantDialog 1`] = `
 <
-  BackdropComponent={
-    Object {
-      "$$typeof": Symbol(react.forward_ref),
-      "Naked": Object {
-        "$$typeof": Symbol(react.forward_ref),
-        "propTypes": Object {
-          "children": [Function],
-          "className": [Function],
-          "classes": [Function],
-          "invisible": [Function],
-          "open": [Function],
-          "transitionDuration": [Function],
-        },
-        "render": [Function],
-      },
-      "options": Object {
-        "defaultTheme": Object {
-          "breakpoints": Object {
-            "between": [Function],
-            "down": [Function],
-            "keys": Array [
-              "xs",
-              "sm",
-              "md",
-              "lg",
-              "xl",
-            ],
-            "only": [Function],
-            "up": [Function],
-            "values": Object {
-              "lg": 1280,
-              "md": 960,
-              "sm": 600,
-              "xl": 1920,
-              "xs": 0,
-            },
-            "width": [Function],
-          },
-          "direction": "ltr",
-          "mixins": Object {
-            "gutters": [Function],
-            "toolbar": Object {
-              "@media (min-width:0px) and (orientation: landscape)": Object {
-                "minHeight": 48,
-              },
-              "@media (min-width:600px)": Object {
-                "minHeight": 64,
-              },
-              "minHeight": 56,
-            },
-          },
-          "overrides": Object {},
-          "palette": Object {
-            "action": Object {
-              "activatedOpacity": 0.12,
-              "active": "rgba(0, 0, 0, 0.54)",
-              "disabled": "rgba(0, 0, 0, 0.26)",
-              "disabledBackground": "rgba(0, 0, 0, 0.12)",
-              "disabledOpacity": 0.38,
-              "focus": "rgba(0, 0, 0, 0.12)",
-              "focusOpacity": 0.12,
-              "hover": "rgba(0, 0, 0, 0.04)",
-              "hoverOpacity": 0.04,
-              "selected": "rgba(0, 0, 0, 0.08)",
-              "selectedOpacity": 0.08,
-            },
-            "augmentColor": [Function],
-            "background": Object {
-              "default": "#fafafa",
-              "paper": "#fff",
-            },
-            "common": Object {
-              "black": "#000",
-              "white": "#fff",
-            },
-            "contrastThreshold": 3,
-            "divider": "rgba(0, 0, 0, 0.12)",
-            "error": Object {
-              "contrastText": "#fff",
-              "dark": "#d32f2f",
-              "light": "#e57373",
-              "main": "#f44336",
-            },
-            "getContrastText": [Function],
-            "grey": Object {
-              "100": "#f5f5f5",
-              "200": "#eeeeee",
-              "300": "#e0e0e0",
-              "400": "#bdbdbd",
-              "50": "#fafafa",
-              "500": "#9e9e9e",
-              "600": "#757575",
-              "700": "#616161",
-              "800": "#424242",
-              "900": "#212121",
-              "A100": "#d5d5d5",
-              "A200": "#aaaaaa",
-              "A400": "#303030",
-              "A700": "#616161",
-            },
-            "info": Object {
-              "contrastText": "#fff",
-              "dark": "#1976d2",
-              "light": "#64b5f6",
-              "main": "#2196f3",
-            },
-            "primary": Object {
-              "contrastText": "#fff",
-              "dark": "#303f9f",
-              "light": "#7986cb",
-              "main": "#3f51b5",
-            },
-            "secondary": Object {
-              "contrastText": "#fff",
-              "dark": "#c51162",
-              "light": "#ff4081",
-              "main": "#f50057",
-            },
-            "success": Object {
-              "contrastText": "rgba(0, 0, 0, 0.87)",
-              "dark": "#388e3c",
-              "light": "#81c784",
-              "main": "#4caf50",
-            },
-            "text": Object {
-              "disabled": "rgba(0, 0, 0, 0.38)",
-              "hint": "rgba(0, 0, 0, 0.38)",
-              "primary": "rgba(0, 0, 0, 0.87)",
-              "secondary": "rgba(0, 0, 0, 0.54)",
-            },
-            "tonalOffset": 0.2,
-            "type": "light",
-            "warning": Object {
-              "contrastText": "rgba(0, 0, 0, 0.87)",
-              "dark": "#f57c00",
-              "light": "#ffb74d",
-              "main": "#ff9800",
-            },
-          },
-          "props": Object {},
-          "shadows": Array [
-            "none",
-            "0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
-            "0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)",
-            "0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)",
-            "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
-            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
-            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
-            "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
-            "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
-            "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
-            "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
-            "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
-            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
-            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
-            "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
-            "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
-            "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
-            "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
-            "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
-            "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
-            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
-            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
-            "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
-            "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
-            "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
-          ],
-          "shape": Object {
-            "borderRadius": 4,
-          },
-          "spacing": [Function],
-          "transitions": Object {
-            "create": [Function],
-            "duration": Object {
-              "complex": 375,
-              "enteringScreen": 225,
-              "leavingScreen": 195,
-              "short": 250,
-              "shorter": 200,
-              "shortest": 150,
-              "standard": 300,
-            },
-            "easing": Object {
-              "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
-              "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
-              "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
-              "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
-            },
-            "getAutoHeightDuration": [Function],
-          },
-          "typography": Object {
-            "body1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00938em",
-              "lineHeight": 1.5,
-            },
-            "body2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.01071em",
-              "lineHeight": 1.43,
-            },
-            "button": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.02857em",
-              "lineHeight": 1.75,
-              "textTransform": "uppercase",
-            },
-            "caption": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.75rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.03333em",
-              "lineHeight": 1.66,
-            },
-            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-            "fontSize": 14,
-            "fontWeightBold": 700,
-            "fontWeightLight": 300,
-            "fontWeightMedium": 500,
-            "fontWeightRegular": 400,
-            "h1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "6rem",
-              "fontWeight": 300,
-              "letterSpacing": "-0.01562em",
-              "lineHeight": 1.167,
-            },
-            "h2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "3.75rem",
-              "fontWeight": 300,
-              "letterSpacing": "-0.00833em",
-              "lineHeight": 1.2,
-            },
-            "h3": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "3rem",
-              "fontWeight": 400,
-              "letterSpacing": "0em",
-              "lineHeight": 1.167,
-            },
-            "h4": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "2.125rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00735em",
-              "lineHeight": 1.235,
-            },
-            "h5": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1.5rem",
-              "fontWeight": 400,
-              "letterSpacing": "0em",
-              "lineHeight": 1.334,
-            },
-            "h6": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1.25rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.0075em",
-              "lineHeight": 1.6,
-            },
-            "htmlFontSize": 16,
-            "overline": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.75rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.08333em",
-              "lineHeight": 2.66,
-              "textTransform": "uppercase",
-            },
-            "pxToRem": [Function],
-            "round": [Function],
-            "subtitle1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00938em",
-              "lineHeight": 1.75,
-            },
-            "subtitle2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.00714em",
-              "lineHeight": 1.57,
-            },
-          },
-          "zIndex": Object {
-            "appBar": 1100,
-            "drawer": 1200,
-            "mobileStepper": 1000,
-            "modal": 1300,
-            "snackbar": 1400,
-            "speedDial": 1050,
-            "tooltip": 1500,
-          },
-        },
-        "name": "MuiBackdrop",
-      },
-      "propTypes": Object {
-        "classes": [Function],
-        "innerRef": [Function],
-      },
-      "render": [Function],
-      "useStyles": [Function],
-    }
-  }
-  BackdropProps={
-    Object {
-      "transitionDuration": Object {
-        "enter": 225,
-        "exit": 195,
-      },
-    }
-  }
   aria-label="create service dialog"
-  className="MuiDialog-root R3CreateServiceTenantDialog-root-1"
+  className="MuiDialog-root R3CreateServiceTenantDialog-root-1 css-1h8td7x-MuiDialog-root"
   closeAfterTransition={true}
+  components={
+    Object {
+      "Backdrop": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "__emotion_base": Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "propTypes": Object {
+            "children": [Function],
+            "className": [Function],
+            "classes": [Function],
+            "component": [Function],
+            "components": [Function],
+            "componentsProps": [Function],
+            "invisible": [Function],
+            "open": [Function],
+            "sx": [Function],
+            "transitionDuration": [Function],
+          },
+          "render": [Function],
+        },
+        "__emotion_forwardProp": [Function],
+        "__emotion_real": [Circular],
+        "__emotion_styles": Array [
+          "label:MuiDialog-backdrop;",
+          Object {
+            "zIndex": -1,
+          },
+          [Function],
+        ],
+        "defaultProps": undefined,
+        "render": [Function],
+        "withComponent": [Function],
+      },
+    }
+  }
+  componentsProps={
+    Object {
+      "backdrop": Object {
+        "as": undefined,
+        "transitionDuration": Object {
+          "enter": 225,
+          "exit": 195,
+        },
+      },
+    }
+  }
   disableEscapeKeyDown={false}
   label="create-service-dialog"
+  onClick={[Function]}
   onClose={[Function]}
   open={true}
 >
   <
     appear={true}
     in={true}
-    role="none presentation"
+    role="presentation"
     timeout={
       Object {
         "enter": 225,
@@ -344,78 +69,73 @@ exports[`R3CreateServiceTenantDialog test snapshot for R3CreateServiceTenantDial
     }
   >
     <div
-      className="MuiDialog-container MuiDialog-scrollBody"
+      className="MuiDialog-container MuiDialog-scrollBody css-iz3z40-MuiDialog-container"
       onMouseDown={[Function]}
-      onMouseUp={[Function]}
     >
       <div
-        className="MuiPaper-root MuiDialog-paper MuiDialog-paperScrollBody MuiDialog-paperWidthSm MuiDialog-paperFullWidth MuiPaper-elevation24 MuiPaper-rounded"
+        className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollBody MuiDialog-paperWidthSm MuiDialog-paperFullWidth css-zfoovh-MuiPaper-root-MuiDialog-paper"
         role="dialog"
       >
-        <div
-          className="MuiDialogTitle-root R3CreateServiceTenantDialog-dialogTitle-2"
+        <h2
+          className="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root R3CreateServiceTenantDialog-dialogTitle-2 css-bdhsul-MuiTypography-root-MuiDialogTitle-root"
           label="create-service-dialog"
         >
-          <h2
-            className="MuiTypography-root MuiTypography-h6"
+          <span
+            className="MuiTypography-root MuiTypography-h5 MuiTypography-noWrap R3CreateServiceTenantDialog-title-3 css-idtq1y-MuiTypography-root"
           >
-            <span
-              className="MuiTypography-root R3CreateServiceTenantDialog-title-3 MuiTypography-h5 MuiTypography-colorPrimary MuiTypography-noWrap"
-            >
-              Created TENANT cooperation SERVICE
-            </span>
-          </h2>
-        </div>
+            Created TENANT cooperation SERVICE
+          </span>
+        </h2>
         <div
-          className="MuiDialogContent-root R3CreateServiceTenantDialog-dialogContent-4"
+          className="MuiDialogContent-root R3CreateServiceTenantDialog-dialogContent-4 css-ypiqx9-MuiDialogContent-root"
         >
           <span
-            className="MuiTypography-root R3CreateServiceTenantDialog-keyTitle-5 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3CreateServiceTenantDialog-keyTitle-5 css-qxncr6-MuiTypography-root"
           >
             TENANT
           </span>
           <span
-            className="MuiTypography-root R3CreateServiceTenantDialog-value-6 MuiTypography-body1 MuiTypography-colorTextSecondary"
+            className="MuiTypography-root MuiTypography-body1 R3CreateServiceTenantDialog-value-6 css-nrdprl-MuiTypography-root"
           >
             GROUP0:TENANT0
           </span>
           <span
-            className="MuiTypography-root R3CreateServiceTenantDialog-keyTitle-5 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3CreateServiceTenantDialog-keyTitle-5 css-qxncr6-MuiTypography-root"
           >
             SERVICE
           </span>
           <span
-            className="MuiTypography-root R3CreateServiceTenantDialog-value-6 MuiTypography-body1 MuiTypography-colorTextSecondary"
+            className="MuiTypography-root MuiTypography-body1 R3CreateServiceTenantDialog-value-6 css-nrdprl-MuiTypography-root"
           >
             JEST_OWNER_SERVICE_NAME
           </span>
           <span
-            className="MuiTypography-root R3CreateServiceTenantDialog-keyTitle-5 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3CreateServiceTenantDialog-keyTitle-5 css-qxncr6-MuiTypography-root"
           >
             PATH
           </span>
           <span
-            className="MuiTypography-root R3CreateServiceTenantDialog-value-6 MuiTypography-body1 MuiTypography-colorTextSecondary"
+            className="MuiTypography-root MuiTypography-body1 R3CreateServiceTenantDialog-value-6 css-nrdprl-MuiTypography-root"
           >
             yrn:yahoo:JEST_OWNER_SERVICE_NAME::10000
           </span>
           <span
-            className="MuiTypography-root R3CreateServiceTenantDialog-keyTitle-5 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3CreateServiceTenantDialog-keyTitle-5 css-qxncr6-MuiTypography-root"
           >
             Cooperation ROLE (Specify ROLE: Allowed empty)
           </span>
           <div
-            className="MuiFormControl-root MuiTextField-root R3CreateServiceTenantDialog-textField-8"
+            className="MuiFormControl-root MuiTextField-root R3CreateServiceTenantDialog-textField-8 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
           >
             <div
-              className="MuiInputBase-root MuiInput-root MuiInput-underline R3CreateServiceTenantDialog-inputTextField-9 MuiInputBase-formControl MuiInput-formControl"
+              className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3CreateServiceTenantDialog-inputTextField-9 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
               onClick={[Function]}
             >
               <input
                 aria-invalid={false}
                 aria-label="input create path"
                 autoFocus={false}
-                className="MuiInputBase-input MuiInput-input"
+                className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
                 disabled={false}
                 id="service-tenant-textfield-id"
                 onAnimationStart={[Function]}
@@ -431,14 +151,15 @@ exports[`R3CreateServiceTenantDialog test snapshot for R3CreateServiceTenantDial
           </div>
         </div>
         <div
-          className="MuiDialogActions-root MuiDialogActions-spacing"
+          className="MuiDialogActions-root MuiDialogActions-spacing css-hlj6pa-MuiDialogActions-root"
         >
           <button
             aria-label="cancel"
-            className="MuiButtonBase-root MuiButton-root MuiButton-contained R3CreateServiceTenantDialog-cancelButton-10 MuiButton-containedPrimary"
+            className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root R3CreateServiceTenantDialog-cancelButton-10 css-sghohy-MuiButtonBase-root-MuiButton-root"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
+            onContextMenu={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -452,28 +173,26 @@ exports[`R3CreateServiceTenantDialog test snapshot for R3CreateServiceTenantDial
             tabIndex={0}
             type="button"
           >
-            <span
-              className="MuiButton-label"
+            CANCEL
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3CreateServiceTenantDialog-buttonIcon-12 css-i4bv87-MuiSvgIcon-root"
+              data-testid="CancelIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              CANCEL
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root R3CreateServiceTenantDialog-buttonIcon-12"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
-                />
-              </svg>
-            </span>
+              <path
+                d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+              />
+            </svg>
           </button>
           <button
             aria-label="ok"
-            className="MuiButtonBase-root MuiButton-root MuiButton-contained R3CreateServiceTenantDialog-okButton-11 MuiButton-containedSecondary"
+            className="MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root R3CreateServiceTenantDialog-okButton-11 css-zcbmsk-MuiButtonBase-root-MuiButton-root"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
+            onContextMenu={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -487,21 +206,18 @@ exports[`R3CreateServiceTenantDialog test snapshot for R3CreateServiceTenantDial
             tabIndex={0}
             type="button"
           >
-            <span
-              className="MuiButton-label"
+            OK
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3CreateServiceTenantDialog-buttonIcon-12 css-i4bv87-MuiSvgIcon-root"
+              data-testid="CheckCircleIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              OK
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root R3CreateServiceTenantDialog-buttonIcon-12"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                />
-              </svg>
-            </span>
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+              />
+            </svg>
           </button>
         </div>
       </div>

--- a/test/__tests__/__snapshots__/r3formbuttons-test.jsx.snap
+++ b/test/__tests__/__snapshots__/r3formbuttons-test.jsx.snap
@@ -6,10 +6,11 @@ exports[`R3FormButtons test snapshot for R3FormButtons 1`] = `
 >
   <button
     aria-label="cancel"
-    className="MuiButtonBase-root MuiButton-root MuiButton-contained R3FormButtons-cancelButton-2 MuiButton-containedPrimary"
+    className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root R3FormButtons-cancelButton-2 css-sghohy-MuiButtonBase-root-MuiButton-root"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
+    onContextMenu={[Function]}
     onDragLeave={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -23,28 +24,26 @@ exports[`R3FormButtons test snapshot for R3FormButtons 1`] = `
     tabIndex={0}
     type="button"
   >
-    <span
-      className="MuiButton-label"
+    CANCEL
+    <svg
+      aria-hidden={true}
+      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3FormButtons-buttonIcon-4 css-i4bv87-MuiSvgIcon-root"
+      data-testid="CancelIcon"
+      focusable="false"
+      viewBox="0 0 24 24"
     >
-      CANCEL
-      <svg
-        aria-hidden={true}
-        className="MuiSvgIcon-root R3FormButtons-buttonIcon-4"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
-        />
-      </svg>
-    </span>
+      <path
+        d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+      />
+    </svg>
   </button>
   <button
     aria-label="save"
-    className="MuiButtonBase-root MuiButton-root MuiButton-contained R3FormButtons-saveButton-3 MuiButton-containedSecondary"
+    className="MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root R3FormButtons-saveButton-3 css-zcbmsk-MuiButtonBase-root-MuiButton-root"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
+    onContextMenu={[Function]}
     onDragLeave={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -58,21 +57,18 @@ exports[`R3FormButtons test snapshot for R3FormButtons 1`] = `
     tabIndex={0}
     type="button"
   >
-    <span
-      className="MuiButton-label"
+    SAVE
+    <svg
+      aria-hidden={true}
+      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3FormButtons-buttonIcon-4 css-i4bv87-MuiSvgIcon-root"
+      data-testid="CheckCircleIcon"
+      focusable="false"
+      viewBox="0 0 24 24"
     >
-      SAVE
-      <svg
-        aria-hidden={true}
-        className="MuiSvgIcon-root R3FormButtons-buttonIcon-4"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-        />
-      </svg>
-    </span>
+      <path
+        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+      />
+    </svg>
   </button>
 </div>
 `;

--- a/test/__tests__/__snapshots__/r3maintree-test.jsx.snap
+++ b/test/__tests__/__snapshots__/r3maintree-test.jsx.snap
@@ -6,39 +6,41 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
 >
   <div>
     <header
-      className="MuiPaper-root MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary R3MainTree-subheaderAppbar-5 MuiPaper-elevation0"
+      className="MuiPaper-root MuiPaper-elevation MuiPaper-elevation0 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionStatic R3MainTree-subheaderAppbar-5 css-120r8wl-MuiPaper-root-MuiAppBar-root"
     >
       <div
-        className="MuiToolbar-root MuiToolbar-dense R3MainTree-subheaderToolbar-6 MuiToolbar-gutters"
+        className="MuiToolbar-root MuiToolbar-gutters MuiToolbar-dense R3MainTree-subheaderToolbar-6 css-10ltm04-MuiToolbar-root"
       >
         <div
-          className="MuiChip-root R3MainTree-chip-9 MuiChip-colorPrimary"
+          className="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-filledPrimary R3MainTree-chip-9 css-17tfht9-MuiChip-root"
           onKeyDown={[Function]}
           onKeyUp={[Function]}
         >
           <span
-            className="MuiChip-label"
+            className="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
           >
             <span
-              className="MuiTypography-root R3MainTree-chipText-10 MuiTypography-subtitle2"
+              className="MuiTypography-root MuiTypography-subtitle2 R3MainTree-chipText-10 css-1sr7afs-MuiTypography-root"
             >
               TENANT
             </span>
           </span>
         </div>
         <span
-          className="MuiTypography-root R3MainTree-tenantListText-2 MuiTypography-subtitle2 MuiTypography-colorTextSecondary"
+          className="MuiTypography-root MuiTypography-subtitle2 R3MainTree-tenantListText-2 css-1oowxap-MuiTypography-root"
         >
           GROUP0:TENANT0
         </span>
         <button
-          aria-describedby={null}
           aria-label="select tenant"
-          className="MuiButtonBase-root MuiIconButton-root"
+          aria-labelledby={null}
+          className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          data-mui-internal-clone-element={true}
           disabled={false}
           label="select-tenant"
           onBlur={[Function]}
           onClick={[Function]}
+          onContextMenu={[Function]}
           onDragLeave={[Function]}
           onFocus={[Function]}
           onKeyDown={[Function]}
@@ -52,40 +54,36 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
           onTouchMove={[Function]}
           onTouchStart={[Function]}
           tabIndex={0}
-          title="Select tenant"
           type="button"
         >
-          <span
-            className="MuiIconButton-label"
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            data-testid="MoreVertIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
           >
-            <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
-              />
-            </svg>
-          </span>
+            <path
+              d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+            />
+          </svg>
           <span
-            className="MuiTouchRipple-root"
+            className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />
         </button>
       </div>
     </header>
   </div>
   <div
-    className="MuiList-root"
+    className="MuiList-root css-1mk9mw3-MuiList-root"
     id="mainTree-top-list"
   >
     <div>
       <div
-        aria-disabled={false}
-        className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+        className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
         onBlur={[Function]}
         onClick={[Function]}
+        onContextMenu={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -100,11 +98,12 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
         tabIndex={0}
       >
         <div
-          className="MuiListItemIcon-root"
+          className="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
         >
           <svg
             aria-hidden={true}
-            className="MuiSvgIcon-root"
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            data-testid="LabelIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -114,34 +113,35 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
           </svg>
         </div>
         <div
-          className="MuiListItemText-root R3MainTree-listItemText-17"
+          className="MuiListItemText-root R3MainTree-listItemText-17 css-tlelie-MuiListItemText-root"
         >
           <span
-            className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiListItemText-primary css-1491uh5-MuiTypography-root"
           >
             SERVICE
           </span>
         </div>
         <div
-          className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13"
+          className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13 css-cveggr-MuiListItemIcon-root"
         >
           <svg
             aria-hidden={true}
-            className="MuiSvgIcon-root"
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            data-testid="ExpandMoreIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
             <path
-              d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+              d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
             />
           </svg>
         </div>
         <span
-          className="MuiTouchRipple-root"
+          className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
       </div>
       <div
-        className="MuiCollapse-root MuiCollapse-hidden"
+        className="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
         style={
           Object {
             "minHeight": "0px",
@@ -149,20 +149,20 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
         }
       >
         <div
-          className="MuiCollapse-wrapper"
+          className="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
         >
           <div
-            className="MuiCollapse-wrapperInner"
+            className="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              className="MuiList-root"
+              className="MuiList-root css-1mk9mw3-MuiList-root"
             >
               <div>
                 <div
-                  aria-disabled={false}
-                  className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+                  className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
                   onBlur={[Function]}
                   onClick={[Function]}
+                  onContextMenu={[Function]}
                   onDragLeave={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -177,34 +177,35 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                   tabIndex={0}
                 >
                   <div
-                    className="MuiListItemText-root R3MainTree-childListItemText-16"
+                    className="MuiListItemText-root R3MainTree-childListItemText-16 css-tlelie-MuiListItemText-root"
                   >
                     <span
-                      className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle1 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                      className="MuiTypography-root MuiTypography-subtitle1 MuiListItemText-primary css-2siatx-MuiTypography-root"
                     >
                       child_service
                     </span>
                   </div>
                   <div
-                    className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13"
+                    className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13 css-cveggr-MuiListItemIcon-root"
                   >
                     <svg
                       aria-hidden={true}
-                      className="MuiSvgIcon-root"
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      data-testid="ExpandMoreIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
                     >
                       <path
-                        d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                        d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
                       />
                     </svg>
                   </div>
                   <span
-                    className="MuiTouchRipple-root"
+                    className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                   />
                 </div>
                 <div
-                  className="MuiCollapse-root R3MainTree-collapse-14 MuiCollapse-hidden"
+                  className="MuiCollapse-root MuiCollapse-vertical R3MainTree-collapse-14 MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
                   style={
                     Object {
                       "minHeight": "0px",
@@ -212,20 +213,20 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                   }
                 >
                   <div
-                    className="MuiCollapse-wrapper"
+                    className="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
                   >
                     <div
-                      className="MuiCollapse-wrapperInner"
+                      className="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                     >
                       <div
-                        className="MuiList-root"
+                        className="MuiList-root css-1mk9mw3-MuiList-root"
                       >
                         <div>
                           <div
-                            aria-disabled={false}
-                            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+                            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
                             onBlur={[Function]}
                             onClick={[Function]}
+                            onContextMenu={[Function]}
                             onDragLeave={[Function]}
                             onFocus={[Function]}
                             onKeyDown={[Function]}
@@ -240,34 +241,35 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                             tabIndex={0}
                           >
                             <div
-                              className="MuiListItemText-root R3MainTree-childListItemText-16"
+                              className="MuiListItemText-root R3MainTree-childListItemText-16 css-tlelie-MuiListItemText-root"
                             >
                               <span
-                                className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle1 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                                className="MuiTypography-root MuiTypography-subtitle1 MuiListItemText-primary css-2siatx-MuiTypography-root"
                               >
                                 ROLE
                               </span>
                             </div>
                             <div
-                              className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13"
+                              className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13 css-cveggr-MuiListItemIcon-root"
                             >
                               <svg
                                 aria-hidden={true}
-                                className="MuiSvgIcon-root"
+                                className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                                data-testid="ExpandMoreIcon"
                                 focusable="false"
                                 viewBox="0 0 24 24"
                               >
                                 <path
-                                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                                  d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
                                 />
                               </svg>
                             </div>
                             <span
-                              className="MuiTouchRipple-root"
+                              className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                             />
                           </div>
                           <div
-                            className="MuiCollapse-root R3MainTree-collapse-14 MuiCollapse-hidden"
+                            className="MuiCollapse-root MuiCollapse-vertical R3MainTree-collapse-14 MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
                             style={
                               Object {
                                 "minHeight": "0px",
@@ -275,20 +277,20 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                             }
                           >
                             <div
-                              className="MuiCollapse-wrapper"
+                              className="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
                             >
                               <div
-                                className="MuiCollapse-wrapperInner"
+                                className="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                               >
                                 <div
-                                  className="MuiList-root"
+                                  className="MuiList-root css-1mk9mw3-MuiList-root"
                                 >
                                   <div>
                                     <div
-                                      aria-disabled={false}
-                                      className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+                                      className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
                                       onBlur={[Function]}
                                       onClick={[Function]}
+                                      onContextMenu={[Function]}
                                       onDragLeave={[Function]}
                                       onFocus={[Function]}
                                       onKeyDown={[Function]}
@@ -303,16 +305,16 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                                       tabIndex={0}
                                     >
                                       <div
-                                        className="MuiListItemText-root R3MainTree-childListItemText-16"
+                                        className="MuiListItemText-root R3MainTree-childListItemText-16 css-tlelie-MuiListItemText-root"
                                       >
                                         <span
-                                          className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle1 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                                          className="MuiTypography-root MuiTypography-subtitle1 MuiListItemText-primary css-2siatx-MuiTypography-root"
                                         >
                                           dummyservicerole
                                         </span>
                                       </div>
                                       <span
-                                        className="MuiTouchRipple-root"
+                                        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                                       />
                                     </div>
                                   </div>
@@ -323,10 +325,10 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                         </div>
                         <div>
                           <div
-                            aria-disabled={false}
-                            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+                            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
                             onBlur={[Function]}
                             onClick={[Function]}
+                            onContextMenu={[Function]}
                             onDragLeave={[Function]}
                             onFocus={[Function]}
                             onKeyDown={[Function]}
@@ -341,34 +343,35 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                             tabIndex={0}
                           >
                             <div
-                              className="MuiListItemText-root R3MainTree-childListItemText-16"
+                              className="MuiListItemText-root R3MainTree-childListItemText-16 css-tlelie-MuiListItemText-root"
                             >
                               <span
-                                className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle1 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                                className="MuiTypography-root MuiTypography-subtitle1 MuiListItemText-primary css-2siatx-MuiTypography-root"
                               >
                                 RESOURCE
                               </span>
                             </div>
                             <div
-                              className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13"
+                              className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13 css-cveggr-MuiListItemIcon-root"
                             >
                               <svg
                                 aria-hidden={true}
-                                className="MuiSvgIcon-root"
+                                className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                                data-testid="ExpandMoreIcon"
                                 focusable="false"
                                 viewBox="0 0 24 24"
                               >
                                 <path
-                                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                                  d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
                                 />
                               </svg>
                             </div>
                             <span
-                              className="MuiTouchRipple-root"
+                              className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                             />
                           </div>
                           <div
-                            className="MuiCollapse-root R3MainTree-collapse-14 MuiCollapse-hidden"
+                            className="MuiCollapse-root MuiCollapse-vertical R3MainTree-collapse-14 MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
                             style={
                               Object {
                                 "minHeight": "0px",
@@ -376,20 +379,20 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                             }
                           >
                             <div
-                              className="MuiCollapse-wrapper"
+                              className="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
                             >
                               <div
-                                className="MuiCollapse-wrapperInner"
+                                className="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                               >
                                 <div
-                                  className="MuiList-root"
+                                  className="MuiList-root css-1mk9mw3-MuiList-root"
                                 >
                                   <div>
                                     <div
-                                      aria-disabled={false}
-                                      className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+                                      className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
                                       onBlur={[Function]}
                                       onClick={[Function]}
+                                      onContextMenu={[Function]}
                                       onDragLeave={[Function]}
                                       onFocus={[Function]}
                                       onKeyDown={[Function]}
@@ -404,16 +407,16 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                                       tabIndex={0}
                                     >
                                       <div
-                                        className="MuiListItemText-root R3MainTree-childListItemText-16"
+                                        className="MuiListItemText-root R3MainTree-childListItemText-16 css-tlelie-MuiListItemText-root"
                                       >
                                         <span
-                                          className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle1 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                                          className="MuiTypography-root MuiTypography-subtitle1 MuiListItemText-primary css-2siatx-MuiTypography-root"
                                         >
                                           dummyserviceresource
                                         </span>
                                       </div>
                                       <span
-                                        className="MuiTouchRipple-root"
+                                        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                                       />
                                     </div>
                                   </div>
@@ -424,10 +427,10 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                         </div>
                         <div>
                           <div
-                            aria-disabled={false}
-                            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+                            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
                             onBlur={[Function]}
                             onClick={[Function]}
+                            onContextMenu={[Function]}
                             onDragLeave={[Function]}
                             onFocus={[Function]}
                             onKeyDown={[Function]}
@@ -442,34 +445,35 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                             tabIndex={0}
                           >
                             <div
-                              className="MuiListItemText-root R3MainTree-childListItemText-16"
+                              className="MuiListItemText-root R3MainTree-childListItemText-16 css-tlelie-MuiListItemText-root"
                             >
                               <span
-                                className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle1 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                                className="MuiTypography-root MuiTypography-subtitle1 MuiListItemText-primary css-2siatx-MuiTypography-root"
                               >
                                 POLICY
                               </span>
                             </div>
                             <div
-                              className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13"
+                              className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13 css-cveggr-MuiListItemIcon-root"
                             >
                               <svg
                                 aria-hidden={true}
-                                className="MuiSvgIcon-root"
+                                className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                                data-testid="ExpandMoreIcon"
                                 focusable="false"
                                 viewBox="0 0 24 24"
                               >
                                 <path
-                                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                                  d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
                                 />
                               </svg>
                             </div>
                             <span
-                              className="MuiTouchRipple-root"
+                              className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                             />
                           </div>
                           <div
-                            className="MuiCollapse-root R3MainTree-collapse-14 MuiCollapse-hidden"
+                            className="MuiCollapse-root MuiCollapse-vertical R3MainTree-collapse-14 MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
                             style={
                               Object {
                                 "minHeight": "0px",
@@ -477,20 +481,20 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                             }
                           >
                             <div
-                              className="MuiCollapse-wrapper"
+                              className="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
                             >
                               <div
-                                className="MuiCollapse-wrapperInner"
+                                className="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                               >
                                 <div
-                                  className="MuiList-root"
+                                  className="MuiList-root css-1mk9mw3-MuiList-root"
                                 >
                                   <div>
                                     <div
-                                      aria-disabled={false}
-                                      className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+                                      className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
                                       onBlur={[Function]}
                                       onClick={[Function]}
+                                      onContextMenu={[Function]}
                                       onDragLeave={[Function]}
                                       onFocus={[Function]}
                                       onKeyDown={[Function]}
@@ -505,16 +509,16 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                                       tabIndex={0}
                                     >
                                       <div
-                                        className="MuiListItemText-root R3MainTree-childListItemText-16"
+                                        className="MuiListItemText-root R3MainTree-childListItemText-16 css-tlelie-MuiListItemText-root"
                                       >
                                         <span
-                                          className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle1 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                                          className="MuiTypography-root MuiTypography-subtitle1 MuiListItemText-primary css-2siatx-MuiTypography-root"
                                         >
                                           dummyservicepolicy
                                         </span>
                                       </div>
                                       <span
-                                        className="MuiTouchRipple-root"
+                                        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                                       />
                                     </div>
                                   </div>
@@ -535,10 +539,10 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
     </div>
     <div>
       <div
-        aria-disabled={false}
-        className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+        className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
         onBlur={[Function]}
         onClick={[Function]}
+        onContextMenu={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -553,11 +557,12 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
         tabIndex={0}
       >
         <div
-          className="MuiListItemIcon-root"
+          className="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
         >
           <svg
             aria-hidden={true}
-            className="MuiSvgIcon-root"
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            data-testid="LabelIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -567,34 +572,35 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
           </svg>
         </div>
         <div
-          className="MuiListItemText-root R3MainTree-listItemText-17"
+          className="MuiListItemText-root R3MainTree-listItemText-17 css-tlelie-MuiListItemText-root"
         >
           <span
-            className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiListItemText-primary css-1491uh5-MuiTypography-root"
           >
             ROLE
           </span>
         </div>
         <div
-          className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13"
+          className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13 css-cveggr-MuiListItemIcon-root"
         >
           <svg
             aria-hidden={true}
-            className="MuiSvgIcon-root"
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            data-testid="ExpandMoreIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
             <path
-              d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+              d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
             />
           </svg>
         </div>
         <span
-          className="MuiTouchRipple-root"
+          className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
       </div>
       <div
-        className="MuiCollapse-root MuiCollapse-hidden"
+        className="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
         style={
           Object {
             "minHeight": "0px",
@@ -602,20 +608,20 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
         }
       >
         <div
-          className="MuiCollapse-wrapper"
+          className="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
         >
           <div
-            className="MuiCollapse-wrapperInner"
+            className="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              className="MuiList-root"
+              className="MuiList-root css-1mk9mw3-MuiList-root"
             >
               <div>
                 <div
-                  aria-disabled={false}
-                  className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+                  className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
                   onBlur={[Function]}
                   onClick={[Function]}
+                  onContextMenu={[Function]}
                   onDragLeave={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -630,34 +636,35 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                   tabIndex={0}
                 >
                   <div
-                    className="MuiListItemText-root R3MainTree-childListItemText-16"
+                    className="MuiListItemText-root R3MainTree-childListItemText-16 css-tlelie-MuiListItemText-root"
                   >
                     <span
-                      className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle1 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                      className="MuiTypography-root MuiTypography-subtitle1 MuiListItemText-primary css-2siatx-MuiTypography-root"
                     >
                       dummyrole
                     </span>
                   </div>
                   <div
-                    className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13"
+                    className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13 css-cveggr-MuiListItemIcon-root"
                   >
                     <svg
                       aria-hidden={true}
-                      className="MuiSvgIcon-root"
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      data-testid="ExpandMoreIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
                     >
                       <path
-                        d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                        d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
                       />
                     </svg>
                   </div>
                   <span
-                    className="MuiTouchRipple-root"
+                    className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                   />
                 </div>
                 <div
-                  className="MuiCollapse-root R3MainTree-collapse-14 MuiCollapse-hidden"
+                  className="MuiCollapse-root MuiCollapse-vertical R3MainTree-collapse-14 MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
                   style={
                     Object {
                       "minHeight": "0px",
@@ -665,20 +672,20 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                   }
                 >
                   <div
-                    className="MuiCollapse-wrapper"
+                    className="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
                   >
                     <div
-                      className="MuiCollapse-wrapperInner"
+                      className="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                     >
                       <div
-                        className="MuiList-root"
+                        className="MuiList-root css-1mk9mw3-MuiList-root"
                       >
                         <div>
                           <div
-                            aria-disabled={false}
-                            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+                            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
                             onBlur={[Function]}
                             onClick={[Function]}
+                            onContextMenu={[Function]}
                             onDragLeave={[Function]}
                             onFocus={[Function]}
                             onKeyDown={[Function]}
@@ -693,16 +700,16 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                             tabIndex={0}
                           >
                             <div
-                              className="MuiListItemText-root R3MainTree-childListItemText-16"
+                              className="MuiListItemText-root R3MainTree-childListItemText-16 css-tlelie-MuiListItemText-root"
                             >
                               <span
-                                className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle1 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                                className="MuiTypography-root MuiTypography-subtitle1 MuiListItemText-primary css-2siatx-MuiTypography-root"
                               >
                                 dummysubrole
                               </span>
                             </div>
                             <span
-                              className="MuiTouchRipple-root"
+                              className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                             />
                           </div>
                         </div>
@@ -718,10 +725,10 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
     </div>
     <div>
       <div
-        aria-disabled={false}
-        className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+        className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
         onBlur={[Function]}
         onClick={[Function]}
+        onContextMenu={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -736,11 +743,12 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
         tabIndex={0}
       >
         <div
-          className="MuiListItemIcon-root"
+          className="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
         >
           <svg
             aria-hidden={true}
-            className="MuiSvgIcon-root"
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            data-testid="LabelIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -750,34 +758,35 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
           </svg>
         </div>
         <div
-          className="MuiListItemText-root R3MainTree-listItemText-17"
+          className="MuiListItemText-root R3MainTree-listItemText-17 css-tlelie-MuiListItemText-root"
         >
           <span
-            className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiListItemText-primary css-1491uh5-MuiTypography-root"
           >
             RESOURCE
           </span>
         </div>
         <div
-          className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13"
+          className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13 css-cveggr-MuiListItemIcon-root"
         >
           <svg
             aria-hidden={true}
-            className="MuiSvgIcon-root"
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            data-testid="ExpandMoreIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
             <path
-              d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+              d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
             />
           </svg>
         </div>
         <span
-          className="MuiTouchRipple-root"
+          className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
       </div>
       <div
-        className="MuiCollapse-root MuiCollapse-hidden"
+        className="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
         style={
           Object {
             "minHeight": "0px",
@@ -785,20 +794,20 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
         }
       >
         <div
-          className="MuiCollapse-wrapper"
+          className="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
         >
           <div
-            className="MuiCollapse-wrapperInner"
+            className="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              className="MuiList-root"
+              className="MuiList-root css-1mk9mw3-MuiList-root"
             >
               <div>
                 <div
-                  aria-disabled={false}
-                  className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+                  className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
                   onBlur={[Function]}
                   onClick={[Function]}
+                  onContextMenu={[Function]}
                   onDragLeave={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -813,34 +822,35 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                   tabIndex={0}
                 >
                   <div
-                    className="MuiListItemText-root R3MainTree-childListItemText-16"
+                    className="MuiListItemText-root R3MainTree-childListItemText-16 css-tlelie-MuiListItemText-root"
                   >
                     <span
-                      className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle1 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                      className="MuiTypography-root MuiTypography-subtitle1 MuiListItemText-primary css-2siatx-MuiTypography-root"
                     >
                       dummyresource
                     </span>
                   </div>
                   <div
-                    className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13"
+                    className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13 css-cveggr-MuiListItemIcon-root"
                   >
                     <svg
                       aria-hidden={true}
-                      className="MuiSvgIcon-root"
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      data-testid="ExpandMoreIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
                     >
                       <path
-                        d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                        d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
                       />
                     </svg>
                   </div>
                   <span
-                    className="MuiTouchRipple-root"
+                    className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                   />
                 </div>
                 <div
-                  className="MuiCollapse-root R3MainTree-collapse-14 MuiCollapse-hidden"
+                  className="MuiCollapse-root MuiCollapse-vertical R3MainTree-collapse-14 MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
                   style={
                     Object {
                       "minHeight": "0px",
@@ -848,20 +858,20 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                   }
                 >
                   <div
-                    className="MuiCollapse-wrapper"
+                    className="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
                   >
                     <div
-                      className="MuiCollapse-wrapperInner"
+                      className="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                     >
                       <div
-                        className="MuiList-root"
+                        className="MuiList-root css-1mk9mw3-MuiList-root"
                       >
                         <div>
                           <div
-                            aria-disabled={false}
-                            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+                            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
                             onBlur={[Function]}
                             onClick={[Function]}
+                            onContextMenu={[Function]}
                             onDragLeave={[Function]}
                             onFocus={[Function]}
                             onKeyDown={[Function]}
@@ -876,16 +886,16 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                             tabIndex={0}
                           >
                             <div
-                              className="MuiListItemText-root R3MainTree-childListItemText-16"
+                              className="MuiListItemText-root R3MainTree-childListItemText-16 css-tlelie-MuiListItemText-root"
                             >
                               <span
-                                className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle1 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                                className="MuiTypography-root MuiTypography-subtitle1 MuiListItemText-primary css-2siatx-MuiTypography-root"
                               >
                                 dummysubresource
                               </span>
                             </div>
                             <span
-                              className="MuiTouchRipple-root"
+                              className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                             />
                           </div>
                         </div>
@@ -901,10 +911,10 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
     </div>
     <div>
       <div
-        aria-disabled={false}
-        className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+        className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
         onBlur={[Function]}
         onClick={[Function]}
+        onContextMenu={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -919,11 +929,12 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
         tabIndex={0}
       >
         <div
-          className="MuiListItemIcon-root"
+          className="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
         >
           <svg
             aria-hidden={true}
-            className="MuiSvgIcon-root"
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            data-testid="LabelIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -933,34 +944,35 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
           </svg>
         </div>
         <div
-          className="MuiListItemText-root R3MainTree-listItemText-17"
+          className="MuiListItemText-root R3MainTree-listItemText-17 css-tlelie-MuiListItemText-root"
         >
           <span
-            className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiListItemText-primary css-1491uh5-MuiTypography-root"
           >
             POLICY
           </span>
         </div>
         <div
-          className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13"
+          className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13 css-cveggr-MuiListItemIcon-root"
         >
           <svg
             aria-hidden={true}
-            className="MuiSvgIcon-root"
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            data-testid="ExpandMoreIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
             <path
-              d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+              d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
             />
           </svg>
         </div>
         <span
-          className="MuiTouchRipple-root"
+          className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
       </div>
       <div
-        className="MuiCollapse-root MuiCollapse-hidden"
+        className="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
         style={
           Object {
             "minHeight": "0px",
@@ -968,20 +980,20 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
         }
       >
         <div
-          className="MuiCollapse-wrapper"
+          className="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
         >
           <div
-            className="MuiCollapse-wrapperInner"
+            className="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              className="MuiList-root"
+              className="MuiList-root css-1mk9mw3-MuiList-root"
             >
               <div>
                 <div
-                  aria-disabled={false}
-                  className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+                  className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
                   onBlur={[Function]}
                   onClick={[Function]}
+                  onContextMenu={[Function]}
                   onDragLeave={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -996,34 +1008,35 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                   tabIndex={0}
                 >
                   <div
-                    className="MuiListItemText-root R3MainTree-childListItemText-16"
+                    className="MuiListItemText-root R3MainTree-childListItemText-16 css-tlelie-MuiListItemText-root"
                   >
                     <span
-                      className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle1 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                      className="MuiTypography-root MuiTypography-subtitle1 MuiListItemText-primary css-2siatx-MuiTypography-root"
                     >
                       dummypolicy
                     </span>
                   </div>
                   <div
-                    className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13"
+                    className="MuiListItemIcon-root R3MainTree-expandListItemIcon-13 css-cveggr-MuiListItemIcon-root"
                   >
                     <svg
                       aria-hidden={true}
-                      className="MuiSvgIcon-root"
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      data-testid="ExpandMoreIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
                     >
                       <path
-                        d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                        d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
                       />
                     </svg>
                   </div>
                   <span
-                    className="MuiTouchRipple-root"
+                    className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                   />
                 </div>
                 <div
-                  className="MuiCollapse-root R3MainTree-collapse-14 MuiCollapse-hidden"
+                  className="MuiCollapse-root MuiCollapse-vertical R3MainTree-collapse-14 MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
                   style={
                     Object {
                       "minHeight": "0px",
@@ -1031,20 +1044,20 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                   }
                 >
                   <div
-                    className="MuiCollapse-wrapper"
+                    className="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
                   >
                     <div
-                      className="MuiCollapse-wrapperInner"
+                      className="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                     >
                       <div
-                        className="MuiList-root"
+                        className="MuiList-root css-1mk9mw3-MuiList-root"
                       >
                         <div>
                           <div
-                            aria-disabled={false}
-                            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+                            className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
                             onBlur={[Function]}
                             onClick={[Function]}
+                            onContextMenu={[Function]}
                             onDragLeave={[Function]}
                             onFocus={[Function]}
                             onKeyDown={[Function]}
@@ -1059,16 +1072,16 @@ exports[`R3MainTree test snapshot for R3MainTree 1`] = `
                             tabIndex={0}
                           >
                             <div
-                              className="MuiListItemText-root R3MainTree-childListItemText-16"
+                              className="MuiListItemText-root R3MainTree-childListItemText-16 css-tlelie-MuiListItemText-root"
                             >
                               <span
-                                className="MuiTypography-root MuiListItemText-primary MuiTypography-subtitle1 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                                className="MuiTypography-root MuiTypography-subtitle1 MuiListItemText-primary css-2siatx-MuiTypography-root"
                               >
                                 dummysubpolicy
                               </span>
                             </div>
                             <span
-                              className="MuiTouchRipple-root"
+                              className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                             />
                           </div>
                         </div>

--- a/test/__tests__/__snapshots__/r3msgbox-test.jsx.snap
+++ b/test/__tests__/__snapshots__/r3msgbox-test.jsx.snap
@@ -2,11 +2,12 @@
 
 exports[`R3MsgBox test snapshot for R3MsgBox 1`] = `
 <div
-  className="MuiPaper-root R3MsgBox-root-1 MuiPaper-elevation2 MuiPaper-rounded"
+  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 R3MsgBox-root-1 css-1mbunh-MuiPaper-root"
 >
   <svg
     aria-hidden={true}
-    className="MuiSvgIcon-root R3MsgBox-errorIcon-5 MuiSvgIcon-colorError"
+    className="MuiSvgIcon-root MuiSvgIcon-colorError MuiSvgIcon-fontSizeMedium R3MsgBox-errorIcon-5 css-1wxstni-MuiSvgIcon-root"
+    data-testid="ErrorRoundedIcon"
     focusable="false"
     viewBox="0 0 24 24"
   >
@@ -15,7 +16,7 @@ exports[`R3MsgBox test snapshot for R3MsgBox 1`] = `
     />
   </svg>
   <span
-    className="MuiTypography-root R3MsgBox-dialogErrorContentText-2 MuiTypography-body1 MuiTypography-colorError"
+    className="MuiTypography-root MuiTypography-body1 R3MsgBox-dialogErrorContentText-2 css-142kxab-MuiTypography-root"
   >
     Dummy error message
     <br />

--- a/test/__tests__/__snapshots__/r3pathinfodialog-test.jsx.snap
+++ b/test/__tests__/__snapshots__/r3pathinfodialog-test.jsx.snap
@@ -2,341 +2,66 @@
 
 exports[`R3PathInfoDialog test snapshot for R3PathInfoDialog 1`] = `
 <
-  BackdropComponent={
-    Object {
-      "$$typeof": Symbol(react.forward_ref),
-      "Naked": Object {
-        "$$typeof": Symbol(react.forward_ref),
-        "propTypes": Object {
-          "children": [Function],
-          "className": [Function],
-          "classes": [Function],
-          "invisible": [Function],
-          "open": [Function],
-          "transitionDuration": [Function],
-        },
-        "render": [Function],
-      },
-      "options": Object {
-        "defaultTheme": Object {
-          "breakpoints": Object {
-            "between": [Function],
-            "down": [Function],
-            "keys": Array [
-              "xs",
-              "sm",
-              "md",
-              "lg",
-              "xl",
-            ],
-            "only": [Function],
-            "up": [Function],
-            "values": Object {
-              "lg": 1280,
-              "md": 960,
-              "sm": 600,
-              "xl": 1920,
-              "xs": 0,
-            },
-            "width": [Function],
-          },
-          "direction": "ltr",
-          "mixins": Object {
-            "gutters": [Function],
-            "toolbar": Object {
-              "@media (min-width:0px) and (orientation: landscape)": Object {
-                "minHeight": 48,
-              },
-              "@media (min-width:600px)": Object {
-                "minHeight": 64,
-              },
-              "minHeight": 56,
-            },
-          },
-          "overrides": Object {},
-          "palette": Object {
-            "action": Object {
-              "activatedOpacity": 0.12,
-              "active": "rgba(0, 0, 0, 0.54)",
-              "disabled": "rgba(0, 0, 0, 0.26)",
-              "disabledBackground": "rgba(0, 0, 0, 0.12)",
-              "disabledOpacity": 0.38,
-              "focus": "rgba(0, 0, 0, 0.12)",
-              "focusOpacity": 0.12,
-              "hover": "rgba(0, 0, 0, 0.04)",
-              "hoverOpacity": 0.04,
-              "selected": "rgba(0, 0, 0, 0.08)",
-              "selectedOpacity": 0.08,
-            },
-            "augmentColor": [Function],
-            "background": Object {
-              "default": "#fafafa",
-              "paper": "#fff",
-            },
-            "common": Object {
-              "black": "#000",
-              "white": "#fff",
-            },
-            "contrastThreshold": 3,
-            "divider": "rgba(0, 0, 0, 0.12)",
-            "error": Object {
-              "contrastText": "#fff",
-              "dark": "#d32f2f",
-              "light": "#e57373",
-              "main": "#f44336",
-            },
-            "getContrastText": [Function],
-            "grey": Object {
-              "100": "#f5f5f5",
-              "200": "#eeeeee",
-              "300": "#e0e0e0",
-              "400": "#bdbdbd",
-              "50": "#fafafa",
-              "500": "#9e9e9e",
-              "600": "#757575",
-              "700": "#616161",
-              "800": "#424242",
-              "900": "#212121",
-              "A100": "#d5d5d5",
-              "A200": "#aaaaaa",
-              "A400": "#303030",
-              "A700": "#616161",
-            },
-            "info": Object {
-              "contrastText": "#fff",
-              "dark": "#1976d2",
-              "light": "#64b5f6",
-              "main": "#2196f3",
-            },
-            "primary": Object {
-              "contrastText": "#fff",
-              "dark": "#303f9f",
-              "light": "#7986cb",
-              "main": "#3f51b5",
-            },
-            "secondary": Object {
-              "contrastText": "#fff",
-              "dark": "#c51162",
-              "light": "#ff4081",
-              "main": "#f50057",
-            },
-            "success": Object {
-              "contrastText": "rgba(0, 0, 0, 0.87)",
-              "dark": "#388e3c",
-              "light": "#81c784",
-              "main": "#4caf50",
-            },
-            "text": Object {
-              "disabled": "rgba(0, 0, 0, 0.38)",
-              "hint": "rgba(0, 0, 0, 0.38)",
-              "primary": "rgba(0, 0, 0, 0.87)",
-              "secondary": "rgba(0, 0, 0, 0.54)",
-            },
-            "tonalOffset": 0.2,
-            "type": "light",
-            "warning": Object {
-              "contrastText": "rgba(0, 0, 0, 0.87)",
-              "dark": "#f57c00",
-              "light": "#ffb74d",
-              "main": "#ff9800",
-            },
-          },
-          "props": Object {},
-          "shadows": Array [
-            "none",
-            "0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
-            "0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)",
-            "0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)",
-            "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
-            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
-            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
-            "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
-            "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
-            "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
-            "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
-            "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
-            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
-            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
-            "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
-            "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
-            "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
-            "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
-            "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
-            "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
-            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
-            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
-            "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
-            "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
-            "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
-          ],
-          "shape": Object {
-            "borderRadius": 4,
-          },
-          "spacing": [Function],
-          "transitions": Object {
-            "create": [Function],
-            "duration": Object {
-              "complex": 375,
-              "enteringScreen": 225,
-              "leavingScreen": 195,
-              "short": 250,
-              "shorter": 200,
-              "shortest": 150,
-              "standard": 300,
-            },
-            "easing": Object {
-              "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
-              "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
-              "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
-              "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
-            },
-            "getAutoHeightDuration": [Function],
-          },
-          "typography": Object {
-            "body1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00938em",
-              "lineHeight": 1.5,
-            },
-            "body2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.01071em",
-              "lineHeight": 1.43,
-            },
-            "button": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.02857em",
-              "lineHeight": 1.75,
-              "textTransform": "uppercase",
-            },
-            "caption": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.75rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.03333em",
-              "lineHeight": 1.66,
-            },
-            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-            "fontSize": 14,
-            "fontWeightBold": 700,
-            "fontWeightLight": 300,
-            "fontWeightMedium": 500,
-            "fontWeightRegular": 400,
-            "h1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "6rem",
-              "fontWeight": 300,
-              "letterSpacing": "-0.01562em",
-              "lineHeight": 1.167,
-            },
-            "h2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "3.75rem",
-              "fontWeight": 300,
-              "letterSpacing": "-0.00833em",
-              "lineHeight": 1.2,
-            },
-            "h3": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "3rem",
-              "fontWeight": 400,
-              "letterSpacing": "0em",
-              "lineHeight": 1.167,
-            },
-            "h4": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "2.125rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00735em",
-              "lineHeight": 1.235,
-            },
-            "h5": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1.5rem",
-              "fontWeight": 400,
-              "letterSpacing": "0em",
-              "lineHeight": 1.334,
-            },
-            "h6": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1.25rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.0075em",
-              "lineHeight": 1.6,
-            },
-            "htmlFontSize": 16,
-            "overline": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.75rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.08333em",
-              "lineHeight": 2.66,
-              "textTransform": "uppercase",
-            },
-            "pxToRem": [Function],
-            "round": [Function],
-            "subtitle1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00938em",
-              "lineHeight": 1.75,
-            },
-            "subtitle2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.00714em",
-              "lineHeight": 1.57,
-            },
-          },
-          "zIndex": Object {
-            "appBar": 1100,
-            "drawer": 1200,
-            "mobileStepper": 1000,
-            "modal": 1300,
-            "snackbar": 1400,
-            "speedDial": 1050,
-            "tooltip": 1500,
-          },
-        },
-        "name": "MuiBackdrop",
-      },
-      "propTypes": Object {
-        "classes": [Function],
-        "innerRef": [Function],
-      },
-      "render": [Function],
-      "useStyles": [Function],
-    }
-  }
-  BackdropProps={
-    Object {
-      "transitionDuration": Object {
-        "enter": 225,
-        "exit": 195,
-      },
-    }
-  }
   aria-label="path information dialog"
-  className="MuiDialog-root R3PathInfoDialog-root-1"
+  className="MuiDialog-root R3PathInfoDialog-root-1 css-1h8td7x-MuiDialog-root"
   closeAfterTransition={true}
+  components={
+    Object {
+      "Backdrop": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "__emotion_base": Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "propTypes": Object {
+            "children": [Function],
+            "className": [Function],
+            "classes": [Function],
+            "component": [Function],
+            "components": [Function],
+            "componentsProps": [Function],
+            "invisible": [Function],
+            "open": [Function],
+            "sx": [Function],
+            "transitionDuration": [Function],
+          },
+          "render": [Function],
+        },
+        "__emotion_forwardProp": [Function],
+        "__emotion_real": [Circular],
+        "__emotion_styles": Array [
+          "label:MuiDialog-backdrop;",
+          Object {
+            "zIndex": -1,
+          },
+          [Function],
+        ],
+        "defaultProps": undefined,
+        "render": [Function],
+        "withComponent": [Function],
+      },
+    }
+  }
+  componentsProps={
+    Object {
+      "backdrop": Object {
+        "as": undefined,
+        "transitionDuration": Object {
+          "enter": 225,
+          "exit": 195,
+        },
+      },
+    }
+  }
   disableEscapeKeyDown={false}
   disablePortal={true}
   label="path-information-dialog"
+  onClick={[Function]}
   onClose={[Function]}
   open={true}
 >
   <
     appear={true}
     in={true}
-    role="none presentation"
+    role="presentation"
     timeout={
       Object {
         "enter": 225,
@@ -345,71 +70,67 @@ exports[`R3PathInfoDialog test snapshot for R3PathInfoDialog 1`] = `
     }
   >
     <div
-      className="MuiDialog-container MuiDialog-scrollBody"
+      className="MuiDialog-container MuiDialog-scrollBody css-iz3z40-MuiDialog-container"
       onMouseDown={[Function]}
-      onMouseUp={[Function]}
     >
       <div
-        className="MuiPaper-root MuiDialog-paper MuiDialog-paperScrollBody MuiDialog-paperWidthSm MuiDialog-paperFullWidth MuiPaper-elevation24 MuiPaper-rounded"
+        className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollBody MuiDialog-paperWidthSm MuiDialog-paperFullWidth css-zfoovh-MuiPaper-root-MuiDialog-paper"
         role="dialog"
       >
-        <div
-          className="MuiDialogTitle-root R3PathInfoDialog-dialogTitle-2"
+        <h2
+          className="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root R3PathInfoDialog-dialogTitle-2 css-bdhsul-MuiTypography-root-MuiDialogTitle-root"
           label="path-information-dialog"
         >
-          <h2
-            className="MuiTypography-root MuiTypography-h6"
+          <span
+            className="MuiTypography-root MuiTypography-h5 MuiTypography-noWrap R3PathInfoDialog-title-3 css-idtq1y-MuiTypography-root"
           >
-            <span
-              className="MuiTypography-root R3PathInfoDialog-title-3 MuiTypography-h5 MuiTypography-colorPrimary MuiTypography-noWrap"
-            >
-              Selected Path Information
-            </span>
-          </h2>
-        </div>
+            Selected Path Information
+          </span>
+        </h2>
         <div
-          className="MuiDialogContent-root R3PathInfoDialog-dialogContent-4"
+          className="MuiDialogContent-root R3PathInfoDialog-dialogContent-4 css-ypiqx9-MuiDialogContent-root"
         >
           <span
-            className="MuiTypography-root R3PathInfoDialog-keyTitle-5 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3PathInfoDialog-keyTitle-5 css-qxncr6-MuiTypography-root"
           >
             TENANT
           </span>
           <span
-            className="MuiTypography-root R3PathInfoDialog-value-6 MuiTypography-body1 MuiTypography-colorTextSecondary"
+            className="MuiTypography-root MuiTypography-body1 R3PathInfoDialog-value-6 css-nrdprl-MuiTypography-root"
           >
             GROUP0:TENANT0
           </span>
           <span
-            className="MuiTypography-root R3PathInfoDialog-keyTitle-5 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3PathInfoDialog-keyTitle-5 css-qxncr6-MuiTypography-root"
           >
             TYPE
           </span>
           <span
-            className="MuiTypography-root R3PathInfoDialog-value-6 MuiTypography-body1 MuiTypography-colorTextSecondary"
+            className="MuiTypography-root MuiTypography-body1 R3PathInfoDialog-value-6 css-nrdprl-MuiTypography-root"
           >
             role
           </span>
           <span
-            className="MuiTypography-root R3PathInfoDialog-keyTitle-5 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3PathInfoDialog-keyTitle-5 css-qxncr6-MuiTypography-root"
           >
             PATH
           </span>
           <span
-            className="MuiTypography-root R3PathInfoDialog-value-6 MuiTypography-body1 MuiTypography-colorTextSecondary"
+            className="MuiTypography-root MuiTypography-body1 R3PathInfoDialog-value-6 css-nrdprl-MuiTypography-root"
           >
             yrn:yahoo:::37146:role:JEST_OWNER_SERVICE
           </span>
         </div>
         <div
-          className="MuiDialogActions-root MuiDialogActions-spacing"
+          className="MuiDialogActions-root MuiDialogActions-spacing css-hlj6pa-MuiDialogActions-root"
         >
           <button
             aria-label="close dialog"
-            className="MuiButtonBase-root MuiButton-root MuiButton-contained R3PathInfoDialog-button-8 MuiButton-containedSecondary"
+            className="MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root R3PathInfoDialog-button-8 css-zcbmsk-MuiButtonBase-root-MuiButton-root"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
+            onContextMenu={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -423,21 +144,18 @@ exports[`R3PathInfoDialog test snapshot for R3PathInfoDialog 1`] = `
             tabIndex={0}
             type="button"
           >
-            <span
-              className="MuiButton-label"
+            CLOSE
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3PathInfoDialog-buttonIcon-10 css-i4bv87-MuiSvgIcon-root"
+              data-testid="CheckCircleIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              CLOSE
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root R3PathInfoDialog-buttonIcon-10"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                />
-              </svg>
-            </span>
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+              />
+            </svg>
           </button>
         </div>
       </div>

--- a/test/__tests__/__snapshots__/r3policy-test.jsx.snap
+++ b/test/__tests__/__snapshots__/r3policy-test.jsx.snap
@@ -5,17 +5,18 @@ exports[`R3Policy test snapshot for R3Policy 1`] = `
   className="R3Policy-root-1"
 >
   <h6
-    className="MuiTypography-root R3Policy-subTitleTop-2 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3Policy-subTitleTop-2 css-qxncr6-MuiTypography-root"
   >
     EFFECT
   </h6>
   <div
-    className="MuiInputBase-root MuiInput-root MuiInput-underline R3Policy-effectSelect-4"
+    className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary R3Policy-effectSelect-4 css-4u4t8f-MuiInputBase-root-MuiInput-root-MuiSelect-root"
     onClick={[Function]}
   >
     <div
+      aria-expanded="false"
       aria-haspopup="listbox"
-      className="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+      className="MuiSelect-select MuiSelect-standard MuiInput-input MuiInputBase-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
       onBlur={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -27,7 +28,8 @@ exports[`R3Policy test snapshot for R3Policy 1`] = `
     </div>
     <input
       aria-hidden={true}
-      className="MuiSelect-nativeInput"
+      className="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+      disabled={false}
       onAnimationStart={[Function]}
       onChange={[Function]}
       tabIndex={-1}
@@ -35,7 +37,8 @@ exports[`R3Policy test snapshot for R3Policy 1`] = `
     />
     <svg
       aria-hidden={true}
-      className="MuiSvgIcon-root MuiSelect-icon"
+      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+      data-testid="ArrowDropDownIcon"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -45,20 +48,20 @@ exports[`R3Policy test snapshot for R3Policy 1`] = `
     </svg>
   </div>
   <h6
-    className="MuiTypography-root R3Policy-subTitle-3 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3Policy-subTitle-3 css-qxncr6-MuiTypography-root"
   >
     ACTION
   </h6>
   <div
-    className="MuiFormGroup-root MuiFormGroup-row"
+    className="MuiFormGroup-root MuiFormGroup-row css-qfz70r-MuiFormGroup-root"
   >
     <label
-      className="MuiFormControlLabel-root R3Policy-actionLeftLabel-6"
+      className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd R3Policy-actionLeftLabel-6 css-j204z7-MuiFormControlLabel-root"
     >
       <span
-        aria-disabled={false}
-        className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-21 MuiCheckbox-root MuiCheckbox-colorSecondary R3Policy-actionCheckbox-5 PrivateSwitchBase-checked-22 Mui-checked MuiIconButton-colorSecondary"
+        className="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root Mui-checked R3Policy-actionCheckbox-5 css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
         onBlur={[Function]}
+        onContextMenu={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -71,50 +74,43 @@ exports[`R3Policy test snapshot for R3Policy 1`] = `
         onTouchStart={[Function]}
         tabIndex={null}
       >
-        <span
-          className="MuiIconButton-label"
+        <input
+          checked={true}
+          className="PrivateSwitchBase-input css-1m9pwf3"
+          data-indeterminate={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
+          value="yrn:yahoo::::action:read"
+        />
+        <svg
+          aria-hidden={true}
+          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          data-testid="CheckBoxIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
         >
-          <input
-            checked={true}
-            className="PrivateSwitchBase-input-24"
-            data-indeterminate={false}
-            disabled={false}
-            onChange={[Function]}
-            type="checkbox"
-            value="yrn:yahoo::::action:read"
+          <path
+            d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
           />
-          <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-            />
-          </svg>
-        </span>
+        </svg>
         <span
-          className="MuiTouchRipple-root"
+          className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
       </span>
-      <span
-        className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+      <p
+        className="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap css-zq04ye-MuiTypography-root"
       >
-        <p
-          className="MuiTypography-root MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-noWrap"
-        >
-          READ
-        </p>
-      </span>
+        READ
+      </p>
     </label>
     <label
-      className="MuiFormControlLabel-root R3Policy-actionEndLabel-8"
+      className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd R3Policy-actionEndLabel-8 css-j204z7-MuiFormControlLabel-root"
     >
       <span
-        aria-disabled={false}
-        className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-21 MuiCheckbox-root MuiCheckbox-colorSecondary R3Policy-actionCheckbox-5 MuiIconButton-colorSecondary"
+        className="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root R3Policy-actionCheckbox-5 css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
         onBlur={[Function]}
+        onContextMenu={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -127,46 +123,39 @@ exports[`R3Policy test snapshot for R3Policy 1`] = `
         onTouchStart={[Function]}
         tabIndex={null}
       >
-        <span
-          className="MuiIconButton-label"
+        <input
+          checked={false}
+          className="PrivateSwitchBase-input css-1m9pwf3"
+          data-indeterminate={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
+          value="yrn:yahoo::::action:write"
+        />
+        <svg
+          aria-hidden={true}
+          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          data-testid="CheckBoxOutlineBlankIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
         >
-          <input
-            checked={false}
-            className="PrivateSwitchBase-input-24"
-            data-indeterminate={false}
-            disabled={false}
-            onChange={[Function]}
-            type="checkbox"
-            value="yrn:yahoo::::action:write"
+          <path
+            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
           />
-          <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-            />
-          </svg>
-        </span>
+        </svg>
         <span
-          className="MuiTouchRipple-root"
+          className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
       </span>
-      <span
-        className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+      <p
+        className="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap css-zq04ye-MuiTypography-root"
       >
-        <p
-          className="MuiTypography-root MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-noWrap"
-        >
-          WRITE
-        </p>
-      </span>
+        WRITE
+      </p>
     </label>
   </div>
   <h6
-    className="MuiTypography-root R3Policy-subTitle-3 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3Policy-subTitle-3 css-qxncr6-MuiTypography-root"
   >
     RESOURCE(YRN)
   </h6>
@@ -174,17 +163,18 @@ exports[`R3Policy test snapshot for R3Policy 1`] = `
     className="R3Policy-enclosureElement-20"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Policy-resourceTextField-9"
+      className="MuiFormControl-root MuiTextField-root R3Policy-resourceTextField-9 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Policy-inputTextField-19 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Policy-inputTextField-19 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-1"
           name="policyResource_0"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -198,13 +188,15 @@ exports[`R3Policy test snapshot for R3Policy 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="delete resource"
-      className="MuiButtonBase-root MuiIconButton-root R3Policy-deleteResourceButton-11"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Policy-deleteResourceButton-11 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="delete-resource"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -218,25 +210,21 @@ exports[`R3Policy test snapshot for R3Policy 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Delete resource YRN path"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="ClearRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18.3 5.71a.9959.9959 0 0 0-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 0 0-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
@@ -244,17 +232,18 @@ exports[`R3Policy test snapshot for R3Policy 1`] = `
     className="R3Policy-enclosureElement-20"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Policy-resourceTextField-9"
+      className="MuiFormControl-root MuiTextField-root R3Policy-resourceTextField-9 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Policy-inputTextField-19 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Policy-inputTextField-19 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-3"
           name="resourceNew"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -268,13 +257,15 @@ exports[`R3Policy test snapshot for R3Policy 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="add resource"
-      className="MuiButtonBase-root MuiIconButton-root R3Policy-addResourceButton-10"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Policy-addResourceButton-10 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="add-resource"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -288,30 +279,26 @@ exports[`R3Policy test snapshot for R3Policy 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Add resource YRN path"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="AddRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
   <h6
-    className="MuiTypography-root R3Policy-subTitle-3 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3Policy-subTitle-3 css-qxncr6-MuiTypography-root"
   >
     ALIASES
   </h6>
@@ -319,17 +306,18 @@ exports[`R3Policy test snapshot for R3Policy 1`] = `
     className="R3Policy-enclosureElement-20"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Policy-aliasTextField-13"
+      className="MuiFormControl-root MuiTextField-root R3Policy-aliasTextField-13 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Policy-inputTextField-19 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Policy-inputTextField-19 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-5"
           name="aliasNew"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -343,13 +331,15 @@ exports[`R3Policy test snapshot for R3Policy 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="add alias"
-      className="MuiButtonBase-root MuiIconButton-root R3Policy-addAliasButton-16"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Policy-addAliasButton-16 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="add-alias"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -363,37 +353,34 @@ exports[`R3Policy test snapshot for R3Policy 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Add alias"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="AddRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
   <div
-    className="R3FormButtons-root-25"
+    className="R3FormButtons-root-21"
   >
     <button
       aria-label="cancel"
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained R3FormButtons-cancelButton-26 MuiButton-containedPrimary Mui-disabled Mui-disabled"
+      className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root Mui-disabled R3FormButtons-cancelButton-22 css-sghohy-MuiButtonBase-root-MuiButton-root"
       disabled={true}
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -407,28 +394,26 @@ exports[`R3Policy test snapshot for R3Policy 1`] = `
       tabIndex={-1}
       type="button"
     >
-      <span
-        className="MuiButton-label"
+      CANCEL
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3FormButtons-buttonIcon-24 css-i4bv87-MuiSvgIcon-root"
+        data-testid="CancelIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        CANCEL
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root R3FormButtons-buttonIcon-28"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+        />
+      </svg>
     </button>
     <button
       aria-label="save"
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained R3FormButtons-saveButton-27 MuiButton-containedSecondary Mui-disabled Mui-disabled"
+      className="MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root Mui-disabled R3FormButtons-saveButton-23 css-zcbmsk-MuiButtonBase-root-MuiButton-root"
       disabled={true}
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -442,21 +427,18 @@ exports[`R3Policy test snapshot for R3Policy 1`] = `
       tabIndex={-1}
       type="button"
     >
-      <span
-        className="MuiButton-label"
+      SAVE
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3FormButtons-buttonIcon-24 css-i4bv87-MuiSvgIcon-root"
+        data-testid="CheckCircleIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        SAVE
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root R3FormButtons-buttonIcon-28"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+        />
+      </svg>
     </button>
   </div>
 </div>

--- a/test/__tests__/__snapshots__/r3popupmsgdialog-test.jsx.snap
+++ b/test/__tests__/__snapshots__/r3popupmsgdialog-test.jsx.snap
@@ -2,341 +2,66 @@
 
 exports[`R3PopupMsgDialog test snapshot for R3PopupMsgDialog 1`] = `
 <
-  BackdropComponent={
-    Object {
-      "$$typeof": Symbol(react.forward_ref),
-      "Naked": Object {
-        "$$typeof": Symbol(react.forward_ref),
-        "propTypes": Object {
-          "children": [Function],
-          "className": [Function],
-          "classes": [Function],
-          "invisible": [Function],
-          "open": [Function],
-          "transitionDuration": [Function],
-        },
-        "render": [Function],
-      },
-      "options": Object {
-        "defaultTheme": Object {
-          "breakpoints": Object {
-            "between": [Function],
-            "down": [Function],
-            "keys": Array [
-              "xs",
-              "sm",
-              "md",
-              "lg",
-              "xl",
-            ],
-            "only": [Function],
-            "up": [Function],
-            "values": Object {
-              "lg": 1280,
-              "md": 960,
-              "sm": 600,
-              "xl": 1920,
-              "xs": 0,
-            },
-            "width": [Function],
-          },
-          "direction": "ltr",
-          "mixins": Object {
-            "gutters": [Function],
-            "toolbar": Object {
-              "@media (min-width:0px) and (orientation: landscape)": Object {
-                "minHeight": 48,
-              },
-              "@media (min-width:600px)": Object {
-                "minHeight": 64,
-              },
-              "minHeight": 56,
-            },
-          },
-          "overrides": Object {},
-          "palette": Object {
-            "action": Object {
-              "activatedOpacity": 0.12,
-              "active": "rgba(0, 0, 0, 0.54)",
-              "disabled": "rgba(0, 0, 0, 0.26)",
-              "disabledBackground": "rgba(0, 0, 0, 0.12)",
-              "disabledOpacity": 0.38,
-              "focus": "rgba(0, 0, 0, 0.12)",
-              "focusOpacity": 0.12,
-              "hover": "rgba(0, 0, 0, 0.04)",
-              "hoverOpacity": 0.04,
-              "selected": "rgba(0, 0, 0, 0.08)",
-              "selectedOpacity": 0.08,
-            },
-            "augmentColor": [Function],
-            "background": Object {
-              "default": "#fafafa",
-              "paper": "#fff",
-            },
-            "common": Object {
-              "black": "#000",
-              "white": "#fff",
-            },
-            "contrastThreshold": 3,
-            "divider": "rgba(0, 0, 0, 0.12)",
-            "error": Object {
-              "contrastText": "#fff",
-              "dark": "#d32f2f",
-              "light": "#e57373",
-              "main": "#f44336",
-            },
-            "getContrastText": [Function],
-            "grey": Object {
-              "100": "#f5f5f5",
-              "200": "#eeeeee",
-              "300": "#e0e0e0",
-              "400": "#bdbdbd",
-              "50": "#fafafa",
-              "500": "#9e9e9e",
-              "600": "#757575",
-              "700": "#616161",
-              "800": "#424242",
-              "900": "#212121",
-              "A100": "#d5d5d5",
-              "A200": "#aaaaaa",
-              "A400": "#303030",
-              "A700": "#616161",
-            },
-            "info": Object {
-              "contrastText": "#fff",
-              "dark": "#1976d2",
-              "light": "#64b5f6",
-              "main": "#2196f3",
-            },
-            "primary": Object {
-              "contrastText": "#fff",
-              "dark": "#303f9f",
-              "light": "#7986cb",
-              "main": "#3f51b5",
-            },
-            "secondary": Object {
-              "contrastText": "#fff",
-              "dark": "#c51162",
-              "light": "#ff4081",
-              "main": "#f50057",
-            },
-            "success": Object {
-              "contrastText": "rgba(0, 0, 0, 0.87)",
-              "dark": "#388e3c",
-              "light": "#81c784",
-              "main": "#4caf50",
-            },
-            "text": Object {
-              "disabled": "rgba(0, 0, 0, 0.38)",
-              "hint": "rgba(0, 0, 0, 0.38)",
-              "primary": "rgba(0, 0, 0, 0.87)",
-              "secondary": "rgba(0, 0, 0, 0.54)",
-            },
-            "tonalOffset": 0.2,
-            "type": "light",
-            "warning": Object {
-              "contrastText": "rgba(0, 0, 0, 0.87)",
-              "dark": "#f57c00",
-              "light": "#ffb74d",
-              "main": "#ff9800",
-            },
-          },
-          "props": Object {},
-          "shadows": Array [
-            "none",
-            "0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
-            "0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)",
-            "0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)",
-            "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
-            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
-            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
-            "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
-            "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
-            "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
-            "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
-            "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
-            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
-            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
-            "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
-            "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
-            "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
-            "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
-            "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
-            "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
-            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
-            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
-            "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
-            "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
-            "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
-          ],
-          "shape": Object {
-            "borderRadius": 4,
-          },
-          "spacing": [Function],
-          "transitions": Object {
-            "create": [Function],
-            "duration": Object {
-              "complex": 375,
-              "enteringScreen": 225,
-              "leavingScreen": 195,
-              "short": 250,
-              "shorter": 200,
-              "shortest": 150,
-              "standard": 300,
-            },
-            "easing": Object {
-              "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
-              "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
-              "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
-              "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
-            },
-            "getAutoHeightDuration": [Function],
-          },
-          "typography": Object {
-            "body1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00938em",
-              "lineHeight": 1.5,
-            },
-            "body2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.01071em",
-              "lineHeight": 1.43,
-            },
-            "button": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.02857em",
-              "lineHeight": 1.75,
-              "textTransform": "uppercase",
-            },
-            "caption": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.75rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.03333em",
-              "lineHeight": 1.66,
-            },
-            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-            "fontSize": 14,
-            "fontWeightBold": 700,
-            "fontWeightLight": 300,
-            "fontWeightMedium": 500,
-            "fontWeightRegular": 400,
-            "h1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "6rem",
-              "fontWeight": 300,
-              "letterSpacing": "-0.01562em",
-              "lineHeight": 1.167,
-            },
-            "h2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "3.75rem",
-              "fontWeight": 300,
-              "letterSpacing": "-0.00833em",
-              "lineHeight": 1.2,
-            },
-            "h3": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "3rem",
-              "fontWeight": 400,
-              "letterSpacing": "0em",
-              "lineHeight": 1.167,
-            },
-            "h4": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "2.125rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00735em",
-              "lineHeight": 1.235,
-            },
-            "h5": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1.5rem",
-              "fontWeight": 400,
-              "letterSpacing": "0em",
-              "lineHeight": 1.334,
-            },
-            "h6": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1.25rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.0075em",
-              "lineHeight": 1.6,
-            },
-            "htmlFontSize": 16,
-            "overline": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.75rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.08333em",
-              "lineHeight": 2.66,
-              "textTransform": "uppercase",
-            },
-            "pxToRem": [Function],
-            "round": [Function],
-            "subtitle1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00938em",
-              "lineHeight": 1.75,
-            },
-            "subtitle2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.00714em",
-              "lineHeight": 1.57,
-            },
-          },
-          "zIndex": Object {
-            "appBar": 1100,
-            "drawer": 1200,
-            "mobileStepper": 1000,
-            "modal": 1300,
-            "snackbar": 1400,
-            "speedDial": 1050,
-            "tooltip": 1500,
-          },
-        },
-        "name": "MuiBackdrop",
-      },
-      "propTypes": Object {
-        "classes": [Function],
-        "innerRef": [Function],
-      },
-      "render": [Function],
-      "useStyles": [Function],
-    }
-  }
-  BackdropProps={
-    Object {
-      "transitionDuration": Object {
-        "enter": 225,
-        "exit": 195,
-      },
-    }
-  }
   aria-label="message dialog"
-  className="MuiDialog-root R3PopupMsgDialog-root-1"
+  className="MuiDialog-root R3PopupMsgDialog-root-1 css-1h8td7x-MuiDialog-root"
   closeAfterTransition={true}
+  components={
+    Object {
+      "Backdrop": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "__emotion_base": Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "propTypes": Object {
+            "children": [Function],
+            "className": [Function],
+            "classes": [Function],
+            "component": [Function],
+            "components": [Function],
+            "componentsProps": [Function],
+            "invisible": [Function],
+            "open": [Function],
+            "sx": [Function],
+            "transitionDuration": [Function],
+          },
+          "render": [Function],
+        },
+        "__emotion_forwardProp": [Function],
+        "__emotion_real": [Circular],
+        "__emotion_styles": Array [
+          "label:MuiDialog-backdrop;",
+          Object {
+            "zIndex": -1,
+          },
+          [Function],
+        ],
+        "defaultProps": undefined,
+        "render": [Function],
+        "withComponent": [Function],
+      },
+    }
+  }
+  componentsProps={
+    Object {
+      "backdrop": Object {
+        "as": undefined,
+        "transitionDuration": Object {
+          "enter": 225,
+          "exit": 195,
+        },
+      },
+    }
+  }
   disableEscapeKeyDown={false}
   disablePortal={true}
   label="message-dialog"
+  onClick={[Function]}
   onClose={[Function]}
   open={true}
 >
   <
     appear={true}
     in={true}
-    role="none presentation"
+    role="presentation"
     timeout={
       Object {
         "enter": 225,
@@ -345,34 +70,30 @@ exports[`R3PopupMsgDialog test snapshot for R3PopupMsgDialog 1`] = `
     }
   >
     <div
-      className="MuiDialog-container MuiDialog-scrollBody"
+      className="MuiDialog-container MuiDialog-scrollBody css-iz3z40-MuiDialog-container"
       onMouseDown={[Function]}
-      onMouseUp={[Function]}
     >
       <div
-        className="MuiPaper-root MuiDialog-paper MuiDialog-paperScrollBody MuiDialog-paperWidthSm MuiDialog-paperFullWidth MuiPaper-elevation24 MuiPaper-rounded"
+        className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollBody MuiDialog-paperWidthSm MuiDialog-paperFullWidth css-zfoovh-MuiPaper-root-MuiDialog-paper"
         role="dialog"
       >
-        <div
-          className="MuiDialogTitle-root R3PopupMsgDialog-dialogTitle-2"
+        <h2
+          className="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root R3PopupMsgDialog-dialogTitle-2 css-bdhsul-MuiTypography-root-MuiDialogTitle-root"
           label="message-dialog"
         >
-          <h2
-            className="MuiTypography-root MuiTypography-h6"
+          <span
+            className="MuiTypography-root MuiTypography-h5 MuiTypography-noWrap R3PopupMsgDialog-title-3 css-idtq1y-MuiTypography-root"
           >
-            <span
-              className="MuiTypography-root R3PopupMsgDialog-title-3 MuiTypography-h5 MuiTypography-colorPrimary MuiTypography-noWrap"
-            >
-              MESSAGE FROM JEST TEST
-            </span>
-          </h2>
-        </div>
+            MESSAGE FROM JEST TEST
+          </span>
+        </h2>
         <div
-          className="MuiDialogContent-root R3PopupMsgDialog-dialogContent-4"
+          className="MuiDialogContent-root R3PopupMsgDialog-dialogContent-4 css-ypiqx9-MuiDialogContent-root"
         >
           <svg
             aria-hidden={true}
-            className="MuiSvgIcon-root R3PopupMsgDialog-errorIcon-8 MuiSvgIcon-colorError"
+            className="MuiSvgIcon-root MuiSvgIcon-colorError MuiSvgIcon-fontSizeMedium R3PopupMsgDialog-errorIcon-8 css-1wxstni-MuiSvgIcon-root"
+            data-testid="ErrorRoundedIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -381,20 +102,21 @@ exports[`R3PopupMsgDialog test snapshot for R3PopupMsgDialog 1`] = `
             />
           </svg>
           <span
-            className="MuiTypography-root MuiDialogContentText-root R3PopupMsgDialog-dialogErrorContentText-5 MuiTypography-body1 MuiTypography-colorError"
+            className="MuiDialogContentText-root MuiTypography-root MuiTypography-body1 R3PopupMsgDialog-dialogErrorContentText-5 css-1yev4ov-MuiTypography-root-MuiDialogContentText-root"
           >
             Dummy error message
           </span>
         </div>
         <div
-          className="MuiDialogActions-root MuiDialogActions-spacing"
+          className="MuiDialogActions-root MuiDialogActions-spacing css-hlj6pa-MuiDialogActions-root"
         >
           <button
             aria-label="cancel"
-            className="MuiButtonBase-root MuiButton-root MuiButton-contained R3PopupMsgDialog-cancelButton-12 MuiButton-containedPrimary"
+            className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root R3PopupMsgDialog-cancelButton-12 css-sghohy-MuiButtonBase-root-MuiButton-root"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
+            onContextMenu={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -408,28 +130,26 @@ exports[`R3PopupMsgDialog test snapshot for R3PopupMsgDialog 1`] = `
             tabIndex={0}
             type="button"
           >
-            <span
-              className="MuiButton-label"
+            CANCEL
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3PopupMsgDialog-buttonIcon-13 css-i4bv87-MuiSvgIcon-root"
+              data-testid="CancelIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              CANCEL
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root R3PopupMsgDialog-buttonIcon-13"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
-                />
-              </svg>
-            </span>
+              <path
+                d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+              />
+            </svg>
           </button>
           <button
             aria-label="confirm contents and close dialog"
-            className="MuiButtonBase-root MuiButton-root MuiButton-contained R3PopupMsgDialog-primaryButton-11 MuiButton-containedSecondary"
+            className="MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root R3PopupMsgDialog-primaryButton-11 css-zcbmsk-MuiButtonBase-root-MuiButton-root"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
+            onContextMenu={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -443,21 +163,18 @@ exports[`R3PopupMsgDialog test snapshot for R3PopupMsgDialog 1`] = `
             tabIndex={0}
             type="button"
           >
-            <span
-              className="MuiButton-label"
+            OK
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3PopupMsgDialog-buttonIcon-13 css-i4bv87-MuiSvgIcon-root"
+              data-testid="CheckCircleIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              OK
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root R3PopupMsgDialog-buttonIcon-13"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                />
-              </svg>
-            </span>
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+              />
+            </svg>
           </button>
         </div>
       </div>

--- a/test/__tests__/__snapshots__/r3resource-test.jsx.snap
+++ b/test/__tests__/__snapshots__/r3resource-test.jsx.snap
@@ -5,25 +5,25 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
   className="R3Resource-root-1"
 >
   <h6
-    className="MuiTypography-root R3Resource-subTitleTop-2 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3Resource-subTitleTop-2 css-qxncr6-MuiTypography-root"
   >
     VALUE
   </h6>
   <div
-    className="MuiFormControl-root R3Resource-valueFormControl-4"
+    className="MuiFormControl-root R3Resource-valueFormControl-4 css-1nrlq1o-MuiFormControl-root"
   >
     <div
       aria-label="select resource value type"
-      className="MuiFormGroup-root R3Resource-valueRadioGroup-5"
+      className="MuiFormGroup-root R3Resource-valueRadioGroup-5 css-dmmspl-MuiFormGroup-root"
       role="radiogroup"
     >
       <label
-        className="MuiFormControlLabel-root R3Resource-valueLeftFormControlLabel-6"
+        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd R3Resource-valueLeftFormControlLabel-6 css-j204z7-MuiFormControlLabel-root"
       >
         <span
-          aria-disabled={false}
-          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-24 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+          className="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root css-vqmohf-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
+          onContextMenu={[Function]}
           onDragLeave={[Function]}
           onFocus={[Function]}
           onKeyDown={[Function]}
@@ -36,64 +36,58 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
           onTouchStart={[Function]}
           tabIndex={null}
         >
+          <input
+            checked={false}
+            className="PrivateSwitchBase-input css-1m9pwf3"
+            disabled={false}
+            name="resourceType"
+            onChange={[Function]}
+            type="radio"
+            value="string"
+          />
           <span
-            className="MuiIconButton-label"
+            className="css-hyxlzm"
           >
-            <input
-              checked={false}
-              className="PrivateSwitchBase-input-27"
-              disabled={false}
-              name="resourceType"
-              onChange={[Function]}
-              type="radio"
-              value="string"
-            />
-            <div
-              className="PrivateRadioButtonIcon-root-28"
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hbvpl3-MuiSvgIcon-root"
+              data-testid="RadioButtonUncheckedIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                />
-              </svg>
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-29"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                />
-              </svg>
-            </div>
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+              />
+            </svg>
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hhw7if-MuiSvgIcon-root"
+              data-testid="RadioButtonCheckedIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+              />
+            </svg>
           </span>
           <span
-            className="MuiTouchRipple-root"
+            className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />
         </span>
-        <span
-          className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+        <p
+          className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-7podw6-MuiTypography-root"
         >
-          <p
-            className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary MuiTypography-noWrap"
-          >
-            String Type(text data)
-          </p>
-        </span>
+          String Type(text data)
+        </p>
       </label>
       <label
-        className="MuiFormControlLabel-root R3Resource-valueRightFormControlLabel-7"
+        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd R3Resource-valueRightFormControlLabel-7 css-j204z7-MuiFormControlLabel-root"
       >
         <span
-          aria-disabled={false}
-          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-24 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-25 Mui-checked MuiIconButton-colorSecondary"
+          className="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked css-vqmohf-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
+          onContextMenu={[Function]}
           onDragLeave={[Function]}
           onFocus={[Function]}
           onKeyDown={[Function]}
@@ -106,71 +100,66 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
           onTouchStart={[Function]}
           tabIndex={null}
         >
+          <input
+            checked={true}
+            className="PrivateSwitchBase-input css-1m9pwf3"
+            disabled={false}
+            name="resourceType"
+            onChange={[Function]}
+            type="radio"
+            value="object"
+          />
           <span
-            className="MuiIconButton-label"
+            className="css-hyxlzm"
           >
-            <input
-              checked={true}
-              className="PrivateSwitchBase-input-27"
-              disabled={false}
-              name="resourceType"
-              onChange={[Function]}
-              type="radio"
-              value="object"
-            />
-            <div
-              className="PrivateRadioButtonIcon-root-28 PrivateRadioButtonIcon-checked-30"
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hbvpl3-MuiSvgIcon-root"
+              data-testid="RadioButtonUncheckedIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                />
-              </svg>
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-29"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                />
-              </svg>
-            </div>
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+              />
+            </svg>
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-11zohuh-MuiSvgIcon-root"
+              data-testid="RadioButtonCheckedIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+              />
+            </svg>
           </span>
           <span
-            className="MuiTouchRipple-root"
+            className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />
         </span>
-        <span
-          className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+        <p
+          className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-7podw6-MuiTypography-root"
         >
-          <p
-            className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary MuiTypography-noWrap"
-          >
-            Object Type(string formatted by JSON)
-          </p>
-        </span>
+          Object Type(string formatted by JSON)
+        </p>
       </label>
     </div>
   </div>
   <div
-    className="MuiFormControl-root MuiTextField-root R3Resource-valueTextField-8 MuiFormControl-fullWidth"
+    className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root R3Resource-valueTextField-8 css-wb57ya-MuiFormControl-root-MuiTextField-root"
   >
     <div
-      className="MuiInputBase-root MuiInput-root MuiInput-underline R3Resource-inputTextField-22 MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+      className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl R3Resource-inputTextField-22 css-1a1fmpi-MuiInputBase-root-MuiInput-root"
       onClick={[Function]}
     >
       <input
         aria-invalid={false}
         autoFocus={false}
-        className="MuiInputBase-input MuiInput-input"
+        className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
         disabled={false}
+        id="mui-1"
         name="resourceValue"
         onAnimationStart={[Function]}
         onBlur={[Function]}
@@ -184,17 +173,17 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
     </div>
   </div>
   <h6
-    className="MuiTypography-root R3Resource-subTitle-3 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3Resource-subTitle-3 css-qxncr6-MuiTypography-root"
   >
     KEYS
   </h6>
   <p
-    className="MuiTypography-root R3Resource-keysKeySubTitle-9 MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap R3Resource-keysKeySubTitle-9 css-zq04ye-MuiTypography-root"
   >
     KEY NAME
   </p>
   <p
-    className="MuiTypography-root R3Resource-keysValueSubTitle-10 MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap R3Resource-keysValueSubTitle-10 css-zq04ye-MuiTypography-root"
   >
     VALUE
   </p>
@@ -202,17 +191,18 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
     className="R3Resource-enclosureElement-23"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Resource-keysKeyTextField-11"
+      className="MuiFormControl-root MuiTextField-root R3Resource-keysKeyTextField-11 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Resource-inputTextField-22 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Resource-inputTextField-22 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-2"
           name="resourceKeysKey_1"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -226,17 +216,18 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       </div>
     </div>
     <div
-      className="MuiFormControl-root MuiTextField-root R3Resource-keysValueTextField-12"
+      className="MuiFormControl-root MuiTextField-root R3Resource-keysValueTextField-12 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Resource-inputTextField-22 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Resource-inputTextField-22 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-3"
           name="resourceKeysValue_1"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -250,13 +241,15 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="delete key and value"
-      className="MuiButtonBase-root MuiIconButton-root R3Resource-deleteKeysButton-13"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Resource-deleteKeysButton-13 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="delete-keys"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -270,25 +263,21 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Delete key and value"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="ClearRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18.3 5.71a.9959.9959 0 0 0-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 0 0-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
@@ -296,17 +285,18 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
     className="R3Resource-enclosureElement-23"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Resource-keysKeyTextField-11"
+      className="MuiFormControl-root MuiTextField-root R3Resource-keysKeyTextField-11 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Resource-inputTextField-22 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Resource-inputTextField-22 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-5"
           name="resourceKeysKey_2"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -320,17 +310,18 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       </div>
     </div>
     <div
-      className="MuiFormControl-root MuiTextField-root R3Resource-keysValueTextField-12"
+      className="MuiFormControl-root MuiTextField-root R3Resource-keysValueTextField-12 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Resource-inputTextField-22 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Resource-inputTextField-22 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-6"
           name="resourceKeysValue_2"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -344,13 +335,15 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="delete key and value"
-      className="MuiButtonBase-root MuiIconButton-root R3Resource-deleteKeysButton-13"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Resource-deleteKeysButton-13 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="delete-keys"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -364,25 +357,21 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Delete key and value"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="ClearRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18.3 5.71a.9959.9959 0 0 0-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 0 0-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
@@ -390,17 +379,18 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
     className="R3Resource-enclosureElement-23"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Resource-keysKeyTextField-11"
+      className="MuiFormControl-root MuiTextField-root R3Resource-keysKeyTextField-11 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Resource-inputTextField-22 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Resource-inputTextField-22 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-8"
           name="resourceKeysKey_3"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -414,17 +404,18 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       </div>
     </div>
     <div
-      className="MuiFormControl-root MuiTextField-root R3Resource-keysValueTextField-12"
+      className="MuiFormControl-root MuiTextField-root R3Resource-keysValueTextField-12 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Resource-inputTextField-22 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Resource-inputTextField-22 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-9"
           name="resourceKeysValue_3"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -438,13 +429,15 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="delete key and value"
-      className="MuiButtonBase-root MuiIconButton-root R3Resource-deleteKeysButton-13"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Resource-deleteKeysButton-13 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="delete-keys"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -458,25 +451,21 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Delete key and value"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="ClearRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18.3 5.71a.9959.9959 0 0 0-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 0 0-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
@@ -484,17 +473,18 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
     className="R3Resource-enclosureElement-23"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Resource-keysKeyTextField-11"
+      className="MuiFormControl-root MuiTextField-root R3Resource-keysKeyTextField-11 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Resource-inputTextField-22 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Resource-inputTextField-22 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-11"
           name="resourceKeysNewKey"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -508,17 +498,18 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       </div>
     </div>
     <div
-      className="MuiFormControl-root MuiTextField-root R3Resource-keysValueTextField-12"
+      className="MuiFormControl-root MuiTextField-root R3Resource-keysValueTextField-12 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Resource-inputTextField-22 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Resource-inputTextField-22 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-12"
           name="resourceKeysNewValue"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -532,13 +523,15 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="add key and value"
-      className="MuiButtonBase-root MuiIconButton-root R3Resource-addKeysButton-15"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Resource-addKeysButton-15 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="add-keys"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -552,30 +545,26 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Add key and value"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="AddRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
   <h6
-    className="MuiTypography-root R3Resource-subTitle-3 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3Resource-subTitle-3 css-qxncr6-MuiTypography-root"
   >
     ALIASES
   </h6>
@@ -583,17 +572,18 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
     className="R3Resource-enclosureElement-23"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Resource-aliasTextField-16"
+      className="MuiFormControl-root MuiTextField-root R3Resource-aliasTextField-16 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Resource-inputTextField-22 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Resource-inputTextField-22 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-14"
           name="aliasValue_0"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -608,10 +598,11 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
     </div>
     <button
       aria-label="move to down position in list"
-      className="MuiButtonBase-root MuiIconButton-root R3Resource-arrowInvisibleAliasButton-18 Mui-disabled Mui-disabled"
+      className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge R3Resource-arrowInvisibleAliasButton-18 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
       disabled={true}
       label="move-down-alias"
       onBlur={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -625,27 +616,25 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       tabIndex={-1}
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="ArrowDownwardRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 0 0-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z"
+        />
+      </svg>
     </button>
     <button
       aria-label="move to up position in list"
-      className="MuiButtonBase-root MuiIconButton-root R3Resource-arrowInvisibleAliasButton-18 Mui-disabled Mui-disabled"
+      className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge R3Resource-arrowInvisibleAliasButton-18 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
       disabled={true}
       label="move-up-alias"
       onBlur={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -659,29 +648,28 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       tabIndex={-1}
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="ArrowUpwardRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M13 19V7.83l4.88 4.88c.39.39 1.03.39 1.42 0 .39-.39.39-1.02 0-1.41l-6.59-6.59a.9959.9959 0 00-1.41 0l-6.6 6.58c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L11 7.83V19c0 .55.45 1 1 1s1-.45 1-1z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M13 19V7.83l4.88 4.88c.39.39 1.03.39 1.42 0 .39-.39.39-1.02 0-1.41l-6.59-6.59a.9959.9959 0 0 0-1.41 0l-6.6 6.58c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L11 7.83V19c0 .55.45 1 1 1s1-.45 1-1z"
+        />
+      </svg>
     </button>
     <button
-      aria-describedby={null}
       aria-label="delete alias"
-      className="MuiButtonBase-root MuiIconButton-root R3Resource-deleteAliasButton-20"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Resource-deleteAliasButton-20 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="delete-alias"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -695,25 +683,21 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Delete alias"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="ClearRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18.3 5.71a.9959.9959 0 0 0-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 0 0-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
@@ -721,17 +705,18 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
     className="R3Resource-enclosureElement-23"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Resource-aliasTextField-16"
+      className="MuiFormControl-root MuiTextField-root R3Resource-aliasTextField-16 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Resource-inputTextField-22 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Resource-inputTextField-22 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-16"
           name="aliasNew"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -745,13 +730,15 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="add alias"
-      className="MuiButtonBase-root MuiIconButton-root R3Resource-addAliasButton-19"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Resource-addAliasButton-19 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="add-alias"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -765,37 +752,34 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Add alias"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="AddRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
   <div
-    className="R3FormButtons-root-31"
+    className="R3FormButtons-root-24"
   >
     <button
       aria-label="cancel"
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained R3FormButtons-cancelButton-32 MuiButton-containedPrimary Mui-disabled Mui-disabled"
+      className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root Mui-disabled R3FormButtons-cancelButton-25 css-sghohy-MuiButtonBase-root-MuiButton-root"
       disabled={true}
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -809,28 +793,26 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       tabIndex={-1}
       type="button"
     >
-      <span
-        className="MuiButton-label"
+      CANCEL
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3FormButtons-buttonIcon-27 css-i4bv87-MuiSvgIcon-root"
+        data-testid="CancelIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        CANCEL
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root R3FormButtons-buttonIcon-34"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+        />
+      </svg>
     </button>
     <button
       aria-label="save"
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained R3FormButtons-saveButton-33 MuiButton-containedSecondary Mui-disabled Mui-disabled"
+      className="MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root Mui-disabled R3FormButtons-saveButton-26 css-zcbmsk-MuiButtonBase-root-MuiButton-root"
       disabled={true}
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -844,21 +826,18 @@ exports[`R3Resource test snapshot for R3Resource 1`] = `
       tabIndex={-1}
       type="button"
     >
-      <span
-        className="MuiButton-label"
+      SAVE
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3FormButtons-buttonIcon-27 css-i4bv87-MuiSvgIcon-root"
+        data-testid="CheckCircleIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        SAVE
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root R3FormButtons-buttonIcon-34"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+        />
+      </svg>
     </button>
   </div>
 </div>

--- a/test/__tests__/__snapshots__/r3role-test.jsx.snap
+++ b/test/__tests__/__snapshots__/r3role-test.jsx.snap
@@ -5,17 +5,17 @@ exports[`R3Role test snapshot for R3Role 1`] = `
   className="R3Role-root-1"
 >
   <h6
-    className="MuiTypography-root R3Role-subTitleTop-2 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3Role-subTitleTop-2 css-qxncr6-MuiTypography-root"
   >
     HOST NAMES
   </h6>
   <p
-    className="MuiTypography-root R3Role-hostnameSubTitle-4 MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap R3Role-hostnameSubTitle-4 css-zq04ye-MuiTypography-root"
   >
     HOST NAME
   </p>
   <p
-    className="MuiTypography-root R3Role-hostnameAUXSubTitle-5 MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap R3Role-hostnameAUXSubTitle-5 css-zq04ye-MuiTypography-root"
   >
     AUX
   </p>
@@ -23,17 +23,18 @@ exports[`R3Role test snapshot for R3Role 1`] = `
     className="R3Role-enclosureElement-28"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Role-hostnameTextField-6"
+      className="MuiFormControl-root MuiTextField-root R3Role-hostnameTextField-6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Role-inputTextField-27 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Role-inputTextField-27 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-1"
           name="roleHostname0"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -47,17 +48,18 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       </div>
     </div>
     <div
-      className="MuiFormControl-root MuiTextField-root R3Role-hostnameAUXTextField-7"
+      className="MuiFormControl-root MuiTextField-root R3Role-hostnameAUXTextField-7 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Role-inputTextField-27 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Role-inputTextField-27 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-2"
           name="roleHostnameAUX_0"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -71,13 +73,15 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="delete hostname information"
-      className="MuiButtonBase-root MuiIconButton-root R3Role-deleteHostnameButton-8"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Role-deleteHostnameButton-8 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="delete-hostname"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -91,25 +95,21 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Delete hostname information"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="ClearRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18.3 5.71a.9959.9959 0 0 0-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 0 0-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
@@ -117,17 +117,18 @@ exports[`R3Role test snapshot for R3Role 1`] = `
     className="R3Role-enclosureElement-28"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Role-hostnameTextField-6"
+      className="MuiFormControl-root MuiTextField-root R3Role-hostnameTextField-6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Role-inputTextField-27 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Role-inputTextField-27 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-4"
           name="roleHostname1"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -141,17 +142,18 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       </div>
     </div>
     <div
-      className="MuiFormControl-root MuiTextField-root R3Role-hostnameAUXTextField-7"
+      className="MuiFormControl-root MuiTextField-root R3Role-hostnameAUXTextField-7 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Role-inputTextField-27 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Role-inputTextField-27 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-5"
           name="roleHostnameAUX_1"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -165,13 +167,15 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="delete hostname information"
-      className="MuiButtonBase-root MuiIconButton-root R3Role-deleteHostnameButton-8"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Role-deleteHostnameButton-8 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="delete-hostname"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -185,25 +189,21 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Delete hostname information"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="ClearRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18.3 5.71a.9959.9959 0 0 0-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 0 0-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
@@ -211,17 +211,18 @@ exports[`R3Role test snapshot for R3Role 1`] = `
     className="R3Role-enclosureElement-28"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Role-hostnameTextField-6"
+      className="MuiFormControl-root MuiTextField-root R3Role-hostnameTextField-6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Role-inputTextField-27 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Role-inputTextField-27 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-7"
           name="roleNewHostname"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -235,17 +236,18 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       </div>
     </div>
     <div
-      className="MuiFormControl-root MuiTextField-root R3Role-hostnameAUXTextField-7"
+      className="MuiFormControl-root MuiTextField-root R3Role-hostnameAUXTextField-7 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Role-inputTextField-27 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Role-inputTextField-27 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-8"
           name="roleNewHostnameAUX"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -259,13 +261,15 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="add hostname and AUX"
-      className="MuiButtonBase-root MuiIconButton-root R3Role-addHostnameButton-10"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Role-addHostnameButton-10 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="add-hostname"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -279,40 +283,36 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Add hostname(FQDN) with AUX"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="AddRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
   <h6
-    className="MuiTypography-root R3Role-subTitle-3 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3Role-subTitle-3 css-qxncr6-MuiTypography-root"
   >
     IP ADDRESSES
   </h6>
   <p
-    className="MuiTypography-root R3Role-ipSubTitle-11 MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap R3Role-ipSubTitle-11 css-zq04ye-MuiTypography-root"
   >
     IP ADDRESS
   </p>
   <p
-    className="MuiTypography-root R3Role-ipAUXSubTitle-12 MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap R3Role-ipAUXSubTitle-12 css-zq04ye-MuiTypography-root"
   >
     AUX
   </p>
@@ -320,17 +320,18 @@ exports[`R3Role test snapshot for R3Role 1`] = `
     className="R3Role-enclosureElement-28"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Role-ipTextField-13"
+      className="MuiFormControl-root MuiTextField-root R3Role-ipTextField-13 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline Mui-disabled Mui-disabled MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input Mui-disabled Mui-disabled"
+          className="MuiInput-input MuiInputBase-input Mui-disabled css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={true}
+          id="mui-10"
           name="roleIp0"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -343,17 +344,18 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       </div>
     </div>
     <div
-      className="MuiFormControl-root MuiTextField-root R3Role-ipAUXTextField-14"
+      className="MuiFormControl-root MuiTextField-root R3Role-ipAUXTextField-14 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline Mui-disabled Mui-disabled MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input Mui-disabled Mui-disabled"
+          className="MuiInput-input MuiInputBase-input Mui-disabled css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={true}
+          id="mui-11"
           name="roleIpAUX_0"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -366,13 +368,15 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="delete ip information"
-      className="MuiButtonBase-root MuiIconButton-root R3Role-deleteIpButton-15"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Role-deleteIpButton-15 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="delete-ip"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -386,25 +390,21 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Delete IP address information"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="ClearRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18.3 5.71a.9959.9959 0 0 0-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 0 0-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
@@ -412,17 +412,18 @@ exports[`R3Role test snapshot for R3Role 1`] = `
     className="R3Role-enclosureElement-28"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Role-ipTextField-13"
+      className="MuiFormControl-root MuiTextField-root R3Role-ipTextField-13 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline Mui-disabled Mui-disabled MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input Mui-disabled Mui-disabled"
+          className="MuiInput-input MuiInputBase-input Mui-disabled css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={true}
+          id="mui-13"
           name="roleIp1"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -435,17 +436,18 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       </div>
     </div>
     <div
-      className="MuiFormControl-root MuiTextField-root R3Role-ipAUXTextField-14"
+      className="MuiFormControl-root MuiTextField-root R3Role-ipAUXTextField-14 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline Mui-disabled Mui-disabled MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input Mui-disabled Mui-disabled"
+          className="MuiInput-input MuiInputBase-input Mui-disabled css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={true}
+          id="mui-14"
           name="roleIpAUX_1"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -458,13 +460,15 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="delete ip information"
-      className="MuiButtonBase-root MuiIconButton-root R3Role-deleteIpButton-15"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Role-deleteIpButton-15 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="delete-ip"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -478,25 +482,21 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Delete IP address information"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="ClearRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18.3 5.71a.9959.9959 0 0 0-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 0 0-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
@@ -504,17 +504,18 @@ exports[`R3Role test snapshot for R3Role 1`] = `
     className="R3Role-enclosureElement-28"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Role-ipTextField-13"
+      className="MuiFormControl-root MuiTextField-root R3Role-ipTextField-13 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline Mui-disabled Mui-disabled MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input Mui-disabled Mui-disabled"
+          className="MuiInput-input MuiInputBase-input Mui-disabled css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={true}
+          id="mui-16"
           name="roleIp2"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -527,17 +528,18 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       </div>
     </div>
     <div
-      className="MuiFormControl-root MuiTextField-root R3Role-ipAUXTextField-14"
+      className="MuiFormControl-root MuiTextField-root R3Role-ipAUXTextField-14 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline Mui-disabled Mui-disabled MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input Mui-disabled Mui-disabled"
+          className="MuiInput-input MuiInputBase-input Mui-disabled css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={true}
+          id="mui-17"
           name="roleIpAUX_2"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -550,13 +552,15 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="delete ip information"
-      className="MuiButtonBase-root MuiIconButton-root R3Role-deleteIpButton-15"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Role-deleteIpButton-15 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="delete-ip"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -570,30 +574,26 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Delete IP address information"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="ClearRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18.3 5.71a.9959.9959 0 0 0-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 0 0-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
   <h6
-    className="MuiTypography-root R3Role-subTitle-3 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3Role-subTitle-3 css-qxncr6-MuiTypography-root"
   >
     POLICIES
   </h6>
@@ -601,17 +601,18 @@ exports[`R3Role test snapshot for R3Role 1`] = `
     className="R3Role-enclosureElement-28"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Role-policyTextField-17"
+      className="MuiFormControl-root MuiTextField-root R3Role-policyTextField-17 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Role-inputTextField-27 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Role-inputTextField-27 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-19"
           name="rolePolicy_0"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -625,13 +626,15 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="delete policy"
-      className="MuiButtonBase-root MuiIconButton-root R3Role-deletePolicyButton-19"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Role-deletePolicyButton-19 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="delete-policy"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -645,25 +648,21 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Delete policy YRN path"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="ClearRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18.3 5.71a.9959.9959 0 0 0-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 0 0-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
@@ -671,17 +670,18 @@ exports[`R3Role test snapshot for R3Role 1`] = `
     className="R3Role-enclosureElement-28"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Role-policyTextField-17"
+      className="MuiFormControl-root MuiTextField-root R3Role-policyTextField-17 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Role-inputTextField-27 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Role-inputTextField-27 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-21"
           name="roleNewPolicy"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -695,13 +695,15 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="add policy"
-      className="MuiButtonBase-root MuiIconButton-root R3Role-addPolicyButton-18"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Role-addPolicyButton-18 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="add-policy"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -715,30 +717,26 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Add policy YRN path"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="AddRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
   <h6
-    className="MuiTypography-root R3Role-subTitle-3 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3Role-subTitle-3 css-qxncr6-MuiTypography-root"
   >
     ALIASES
   </h6>
@@ -746,17 +744,18 @@ exports[`R3Role test snapshot for R3Role 1`] = `
     className="R3Role-enclosureElement-28"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Role-aliasTextField-21"
+      className="MuiFormControl-root MuiTextField-root R3Role-aliasTextField-21 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Role-inputTextField-27 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Role-inputTextField-27 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-23"
           name="aliasValue_0"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -771,10 +770,11 @@ exports[`R3Role test snapshot for R3Role 1`] = `
     </div>
     <button
       aria-label="move to down position in list"
-      className="MuiButtonBase-root MuiIconButton-root R3Role-arrowInvisibleAliasButton-23 Mui-disabled Mui-disabled"
+      className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge R3Role-arrowInvisibleAliasButton-23 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
       disabled={true}
       label="move-down-alias"
       onBlur={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -788,27 +788,25 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       tabIndex={-1}
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="ArrowDownwardRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 0 0-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z"
+        />
+      </svg>
     </button>
     <button
       aria-label="move to up position in list"
-      className="MuiButtonBase-root MuiIconButton-root R3Role-arrowInvisibleAliasButton-23 Mui-disabled Mui-disabled"
+      className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge R3Role-arrowInvisibleAliasButton-23 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
       disabled={true}
       label="move-up-alias"
       onBlur={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -822,29 +820,28 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       tabIndex={-1}
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="ArrowUpwardRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M13 19V7.83l4.88 4.88c.39.39 1.03.39 1.42 0 .39-.39.39-1.02 0-1.41l-6.59-6.59a.9959.9959 0 00-1.41 0l-6.6 6.58c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L11 7.83V19c0 .55.45 1 1 1s1-.45 1-1z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M13 19V7.83l4.88 4.88c.39.39 1.03.39 1.42 0 .39-.39.39-1.02 0-1.41l-6.59-6.59a.9959.9959 0 0 0-1.41 0l-6.6 6.58c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L11 7.83V19c0 .55.45 1 1 1s1-.45 1-1z"
+        />
+      </svg>
     </button>
     <button
-      aria-describedby={null}
       aria-label="delete alias"
-      className="MuiButtonBase-root MuiIconButton-root R3Role-deleteAliasButton-25"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Role-deleteAliasButton-25 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="delete-alias"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -858,25 +855,21 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Delete alias"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="ClearRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18.3 5.71a.9959.9959 0 0 0-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 0 0-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
@@ -884,17 +877,18 @@ exports[`R3Role test snapshot for R3Role 1`] = `
     className="R3Role-enclosureElement-28"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Role-aliasTextField-21"
+      className="MuiFormControl-root MuiTextField-root R3Role-aliasTextField-21 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Role-inputTextField-27 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Role-inputTextField-27 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-25"
           name="aliasNew"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -908,13 +902,15 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="add alias"
-      className="MuiButtonBase-root MuiIconButton-root R3Role-addAliasButton-24"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Role-addAliasButton-24 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="add-alias"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -928,25 +924,21 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Add alias"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="AddRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
@@ -955,10 +947,11 @@ exports[`R3Role test snapshot for R3Role 1`] = `
   >
     <button
       aria-label="cancel"
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained R3FormButtons-cancelButton-30 MuiButton-containedPrimary Mui-disabled Mui-disabled"
+      className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root Mui-disabled R3FormButtons-cancelButton-30 css-sghohy-MuiButtonBase-root-MuiButton-root"
       disabled={true}
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -972,28 +965,26 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       tabIndex={-1}
       type="button"
     >
-      <span
-        className="MuiButton-label"
+      CANCEL
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3FormButtons-buttonIcon-32 css-i4bv87-MuiSvgIcon-root"
+        data-testid="CancelIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        CANCEL
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root R3FormButtons-buttonIcon-32"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+        />
+      </svg>
     </button>
     <button
       aria-label="save"
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained R3FormButtons-saveButton-31 MuiButton-containedSecondary Mui-disabled Mui-disabled"
+      className="MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root Mui-disabled R3FormButtons-saveButton-31 css-zcbmsk-MuiButtonBase-root-MuiButton-root"
       disabled={true}
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -1007,21 +998,18 @@ exports[`R3Role test snapshot for R3Role 1`] = `
       tabIndex={-1}
       type="button"
     >
-      <span
-        className="MuiButton-label"
+      SAVE
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3FormButtons-buttonIcon-32 css-i4bv87-MuiSvgIcon-root"
+        data-testid="CheckCircleIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        SAVE
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root R3FormButtons-buttonIcon-32"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+        />
+      </svg>
     </button>
   </div>
 </div>

--- a/test/__tests__/__snapshots__/r3service-test.jsx.snap
+++ b/test/__tests__/__snapshots__/r3service-test.jsx.snap
@@ -5,22 +5,22 @@ exports[`R3Service test snapshot for R3Service 1`] = `
   className="R3Service-root-1"
 >
   <h6
-    className="MuiTypography-root R3Service-subTitleTop-2 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3Service-subTitleTop-2 css-qxncr6-MuiTypography-root"
   >
     SERVICE RESOURCES
   </h6>
   <div
     aria-label="select type verify url or static resource"
-    className="MuiFormGroup-root R3Service-valueRadioGroup-6"
+    className="MuiFormGroup-root R3Service-valueRadioGroup-6 css-dmmspl-MuiFormGroup-root"
     role="radiogroup"
   >
     <label
-      className="MuiFormControlLabel-root R3Service-valueLeftFormControlLabel-7"
+      className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd R3Service-valueLeftFormControlLabel-7 css-j204z7-MuiFormControlLabel-root"
     >
       <span
-        aria-disabled={false}
-        className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-24 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-25 Mui-checked MuiIconButton-colorSecondary"
+        className="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked css-vqmohf-MuiButtonBase-root-MuiRadio-root"
         onBlur={[Function]}
+        onContextMenu={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -33,64 +33,58 @@ exports[`R3Service test snapshot for R3Service 1`] = `
         onTouchStart={[Function]}
         tabIndex={null}
       >
+        <input
+          checked={true}
+          className="PrivateSwitchBase-input css-1m9pwf3"
+          disabled={false}
+          name="serviceResourceType"
+          onChange={[Function]}
+          type="radio"
+          value="verifyUrl"
+        />
         <span
-          className="MuiIconButton-label"
+          className="css-hyxlzm"
         >
-          <input
-            checked={true}
-            className="PrivateSwitchBase-input-27"
-            disabled={false}
-            name="serviceResourceType"
-            onChange={[Function]}
-            type="radio"
-            value="verifyUrl"
-          />
-          <div
-            className="PrivateRadioButtonIcon-root-28 PrivateRadioButtonIcon-checked-30"
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hbvpl3-MuiSvgIcon-root"
+            data-testid="RadioButtonUncheckedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
           >
-            <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-29"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-              />
-            </svg>
-          </div>
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+            />
+          </svg>
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-11zohuh-MuiSvgIcon-root"
+            data-testid="RadioButtonCheckedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+            />
+          </svg>
         </span>
         <span
-          className="MuiTouchRipple-root"
+          className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
       </span>
-      <span
-        className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+      <p
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-7podw6-MuiTypography-root"
       >
-        <p
-          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary MuiTypography-noWrap"
-        >
-          VERIFY URL
-        </p>
-      </span>
+        VERIFY URL
+      </p>
     </label>
     <label
-      className="MuiFormControlLabel-root R3Service-valueRightFormControlLabel-8"
+      className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd R3Service-valueRightFormControlLabel-8 css-j204z7-MuiFormControlLabel-root"
     >
       <span
-        aria-disabled={false}
-        className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-24 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+        className="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root css-vqmohf-MuiButtonBase-root-MuiRadio-root"
         onBlur={[Function]}
+        onContextMenu={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -103,70 +97,65 @@ exports[`R3Service test snapshot for R3Service 1`] = `
         onTouchStart={[Function]}
         tabIndex={null}
       >
+        <input
+          checked={false}
+          className="PrivateSwitchBase-input css-1m9pwf3"
+          disabled={false}
+          name="serviceResourceType"
+          onChange={[Function]}
+          type="radio"
+          value="staticResourceObject"
+        />
         <span
-          className="MuiIconButton-label"
+          className="css-hyxlzm"
         >
-          <input
-            checked={false}
-            className="PrivateSwitchBase-input-27"
-            disabled={false}
-            name="serviceResourceType"
-            onChange={[Function]}
-            type="radio"
-            value="staticResourceObject"
-          />
-          <div
-            className="PrivateRadioButtonIcon-root-28"
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hbvpl3-MuiSvgIcon-root"
+            data-testid="RadioButtonUncheckedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
           >
-            <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-29"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-              />
-            </svg>
-          </div>
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+            />
+          </svg>
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hhw7if-MuiSvgIcon-root"
+            data-testid="RadioButtonCheckedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+            />
+          </svg>
         </span>
         <span
-          className="MuiTouchRipple-root"
+          className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
       </span>
-      <span
-        className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+      <p
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-7podw6-MuiTypography-root"
       >
-        <p
-          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary MuiTypography-noWrap"
-        >
-          STATIC RESOURCE OBJECT
-        </p>
-      </span>
+        STATIC RESOURCE OBJECT
+      </p>
     </label>
   </div>
   <div
-    className="MuiFormControl-root MuiTextField-root R3Service-resourceTextField-4"
+    className="MuiFormControl-root MuiTextField-root R3Service-resourceTextField-4 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
   >
     <div
-      className="MuiInputBase-root MuiInput-root MuiInput-underline R3Service-inputTextField-16 MuiInputBase-formControl MuiInput-formControl"
+      className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Service-inputTextField-16 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
       onClick={[Function]}
     >
       <input
         aria-invalid={false}
         autoFocus={false}
-        className="MuiInputBase-input MuiInput-input"
+        className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
         disabled={false}
+        id="mui-1"
         name="serviceVerifyUrlResource"
         onAnimationStart={[Function]}
         onBlur={[Function]}
@@ -180,7 +169,7 @@ exports[`R3Service test snapshot for R3Service 1`] = `
     </div>
   </div>
   <h6
-    className="MuiTypography-root R3Service-subTitle-3 MuiTypography-subtitle2 MuiTypography-colorPrimary MuiTypography-noWrap"
+    className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3Service-subTitle-3 css-qxncr6-MuiTypography-root"
   >
     TENANTS
   </h6>
@@ -188,17 +177,18 @@ exports[`R3Service test snapshot for R3Service 1`] = `
     className="R3Service-enclosureElement-23"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Service-tenantTextField-17"
+      className="MuiFormControl-root MuiTextField-root R3Service-tenantTextField-17 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Service-inputTextField-16 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Service-inputTextField-16 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-2"
           name="tenantValue_0"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -212,13 +202,15 @@ exports[`R3Service test snapshot for R3Service 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="delete tenant"
-      className="MuiButtonBase-root MuiIconButton-root R3Service-deleteTenantButton-22"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Service-deleteTenantButton-22 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="delete-tenant"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -232,25 +224,21 @@ exports[`R3Service test snapshot for R3Service 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Delete tenant YRN path"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="ClearRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18.3 5.71a.9959.9959 0 0 0-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 0 0-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
@@ -258,17 +246,18 @@ exports[`R3Service test snapshot for R3Service 1`] = `
     className="R3Service-enclosureElement-23"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Service-tenantTextField-17"
+      className="MuiFormControl-root MuiTextField-root R3Service-tenantTextField-17 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Service-inputTextField-16 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Service-inputTextField-16 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-4"
           name="tenantValue_1"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -282,13 +271,15 @@ exports[`R3Service test snapshot for R3Service 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="delete tenant"
-      className="MuiButtonBase-root MuiIconButton-root R3Service-deleteTenantButton-22"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Service-deleteTenantButton-22 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="delete-tenant"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -302,25 +293,21 @@ exports[`R3Service test snapshot for R3Service 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Delete tenant YRN path"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="ClearRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18.3 5.71a.9959.9959 0 0 0-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 0 0-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
@@ -328,17 +315,18 @@ exports[`R3Service test snapshot for R3Service 1`] = `
     className="R3Service-enclosureElement-23"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root R3Service-tenantTextField-17"
+      className="MuiFormControl-root MuiTextField-root R3Service-tenantTextField-17 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline R3Service-inputTextField-16 MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl R3Service-inputTextField-16 css-1ptx2yq-MuiInputBase-root-MuiInput-root"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
           disabled={false}
+          id="mui-6"
           name="tenantNew"
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -352,13 +340,15 @@ exports[`R3Service test snapshot for R3Service 1`] = `
       </div>
     </div>
     <button
-      aria-describedby={null}
       aria-label="add tenant"
-      className="MuiButtonBase-root MuiIconButton-root R3Service-addTenantButton-21"
+      aria-labelledby={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge R3Service-addTenantButton-21 css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element={true}
       disabled={false}
       label="add-tenant"
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -372,37 +362,34 @@ exports[`R3Service test snapshot for R3Service 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      title="Add tenant YRN path"
       type="button"
     >
-      <span
-        className="MuiIconButton-label"
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        data-testid="AddRoundedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
+        />
+      </svg>
       <span
-        className="MuiTouchRipple-root"
+        className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
   </div>
   <div
-    className="R3FormButtons-root-31"
+    className="R3FormButtons-root-24"
   >
     <button
       aria-label="cancel"
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained R3FormButtons-cancelButton-32 MuiButton-containedPrimary Mui-disabled Mui-disabled"
+      className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root Mui-disabled R3FormButtons-cancelButton-25 css-sghohy-MuiButtonBase-root-MuiButton-root"
       disabled={true}
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -416,28 +403,26 @@ exports[`R3Service test snapshot for R3Service 1`] = `
       tabIndex={-1}
       type="button"
     >
-      <span
-        className="MuiButton-label"
+      CANCEL
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3FormButtons-buttonIcon-27 css-i4bv87-MuiSvgIcon-root"
+        data-testid="CancelIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        CANCEL
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root R3FormButtons-buttonIcon-34"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+        />
+      </svg>
     </button>
     <button
       aria-label="save"
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained R3FormButtons-saveButton-33 MuiButton-containedSecondary Mui-disabled Mui-disabled"
+      className="MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root Mui-disabled R3FormButtons-saveButton-26 css-zcbmsk-MuiButtonBase-root-MuiButton-root"
       disabled={true}
       onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -451,21 +436,18 @@ exports[`R3Service test snapshot for R3Service 1`] = `
       tabIndex={-1}
       type="button"
     >
-      <span
-        className="MuiButton-label"
+      SAVE
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3FormButtons-buttonIcon-27 css-i4bv87-MuiSvgIcon-root"
+        data-testid="CheckCircleIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
       >
-        SAVE
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root R3FormButtons-buttonIcon-34"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+        />
+      </svg>
     </button>
   </div>
 </div>

--- a/test/__tests__/__snapshots__/r3signincreddialog-test.jsx.snap
+++ b/test/__tests__/__snapshots__/r3signincreddialog-test.jsx.snap
@@ -1,342 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`R3CreateServiceDialog test snapshot for Rr3SigninCredDialog 1`] = `
+exports[`R3CreateServiceDialog test snapshot for R3SigninCredDialog 1`] = `
 <
-  BackdropComponent={
-    Object {
-      "$$typeof": Symbol(react.forward_ref),
-      "Naked": Object {
-        "$$typeof": Symbol(react.forward_ref),
-        "propTypes": Object {
-          "children": [Function],
-          "className": [Function],
-          "classes": [Function],
-          "invisible": [Function],
-          "open": [Function],
-          "transitionDuration": [Function],
-        },
-        "render": [Function],
-      },
-      "options": Object {
-        "defaultTheme": Object {
-          "breakpoints": Object {
-            "between": [Function],
-            "down": [Function],
-            "keys": Array [
-              "xs",
-              "sm",
-              "md",
-              "lg",
-              "xl",
-            ],
-            "only": [Function],
-            "up": [Function],
-            "values": Object {
-              "lg": 1280,
-              "md": 960,
-              "sm": 600,
-              "xl": 1920,
-              "xs": 0,
-            },
-            "width": [Function],
-          },
-          "direction": "ltr",
-          "mixins": Object {
-            "gutters": [Function],
-            "toolbar": Object {
-              "@media (min-width:0px) and (orientation: landscape)": Object {
-                "minHeight": 48,
-              },
-              "@media (min-width:600px)": Object {
-                "minHeight": 64,
-              },
-              "minHeight": 56,
-            },
-          },
-          "overrides": Object {},
-          "palette": Object {
-            "action": Object {
-              "activatedOpacity": 0.12,
-              "active": "rgba(0, 0, 0, 0.54)",
-              "disabled": "rgba(0, 0, 0, 0.26)",
-              "disabledBackground": "rgba(0, 0, 0, 0.12)",
-              "disabledOpacity": 0.38,
-              "focus": "rgba(0, 0, 0, 0.12)",
-              "focusOpacity": 0.12,
-              "hover": "rgba(0, 0, 0, 0.04)",
-              "hoverOpacity": 0.04,
-              "selected": "rgba(0, 0, 0, 0.08)",
-              "selectedOpacity": 0.08,
-            },
-            "augmentColor": [Function],
-            "background": Object {
-              "default": "#fafafa",
-              "paper": "#fff",
-            },
-            "common": Object {
-              "black": "#000",
-              "white": "#fff",
-            },
-            "contrastThreshold": 3,
-            "divider": "rgba(0, 0, 0, 0.12)",
-            "error": Object {
-              "contrastText": "#fff",
-              "dark": "#d32f2f",
-              "light": "#e57373",
-              "main": "#f44336",
-            },
-            "getContrastText": [Function],
-            "grey": Object {
-              "100": "#f5f5f5",
-              "200": "#eeeeee",
-              "300": "#e0e0e0",
-              "400": "#bdbdbd",
-              "50": "#fafafa",
-              "500": "#9e9e9e",
-              "600": "#757575",
-              "700": "#616161",
-              "800": "#424242",
-              "900": "#212121",
-              "A100": "#d5d5d5",
-              "A200": "#aaaaaa",
-              "A400": "#303030",
-              "A700": "#616161",
-            },
-            "info": Object {
-              "contrastText": "#fff",
-              "dark": "#1976d2",
-              "light": "#64b5f6",
-              "main": "#2196f3",
-            },
-            "primary": Object {
-              "contrastText": "#fff",
-              "dark": "#303f9f",
-              "light": "#7986cb",
-              "main": "#3f51b5",
-            },
-            "secondary": Object {
-              "contrastText": "#fff",
-              "dark": "#c51162",
-              "light": "#ff4081",
-              "main": "#f50057",
-            },
-            "success": Object {
-              "contrastText": "rgba(0, 0, 0, 0.87)",
-              "dark": "#388e3c",
-              "light": "#81c784",
-              "main": "#4caf50",
-            },
-            "text": Object {
-              "disabled": "rgba(0, 0, 0, 0.38)",
-              "hint": "rgba(0, 0, 0, 0.38)",
-              "primary": "rgba(0, 0, 0, 0.87)",
-              "secondary": "rgba(0, 0, 0, 0.54)",
-            },
-            "tonalOffset": 0.2,
-            "type": "light",
-            "warning": Object {
-              "contrastText": "rgba(0, 0, 0, 0.87)",
-              "dark": "#f57c00",
-              "light": "#ffb74d",
-              "main": "#ff9800",
-            },
-          },
-          "props": Object {},
-          "shadows": Array [
-            "none",
-            "0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
-            "0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)",
-            "0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)",
-            "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
-            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
-            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
-            "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
-            "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
-            "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
-            "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
-            "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
-            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
-            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
-            "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
-            "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
-            "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
-            "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
-            "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
-            "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
-            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
-            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
-            "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
-            "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
-            "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
-          ],
-          "shape": Object {
-            "borderRadius": 4,
-          },
-          "spacing": [Function],
-          "transitions": Object {
-            "create": [Function],
-            "duration": Object {
-              "complex": 375,
-              "enteringScreen": 225,
-              "leavingScreen": 195,
-              "short": 250,
-              "shorter": 200,
-              "shortest": 150,
-              "standard": 300,
-            },
-            "easing": Object {
-              "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
-              "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
-              "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
-              "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
-            },
-            "getAutoHeightDuration": [Function],
-          },
-          "typography": Object {
-            "body1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00938em",
-              "lineHeight": 1.5,
-            },
-            "body2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.01071em",
-              "lineHeight": 1.43,
-            },
-            "button": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.02857em",
-              "lineHeight": 1.75,
-              "textTransform": "uppercase",
-            },
-            "caption": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.75rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.03333em",
-              "lineHeight": 1.66,
-            },
-            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-            "fontSize": 14,
-            "fontWeightBold": 700,
-            "fontWeightLight": 300,
-            "fontWeightMedium": 500,
-            "fontWeightRegular": 400,
-            "h1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "6rem",
-              "fontWeight": 300,
-              "letterSpacing": "-0.01562em",
-              "lineHeight": 1.167,
-            },
-            "h2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "3.75rem",
-              "fontWeight": 300,
-              "letterSpacing": "-0.00833em",
-              "lineHeight": 1.2,
-            },
-            "h3": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "3rem",
-              "fontWeight": 400,
-              "letterSpacing": "0em",
-              "lineHeight": 1.167,
-            },
-            "h4": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "2.125rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00735em",
-              "lineHeight": 1.235,
-            },
-            "h5": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1.5rem",
-              "fontWeight": 400,
-              "letterSpacing": "0em",
-              "lineHeight": 1.334,
-            },
-            "h6": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1.25rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.0075em",
-              "lineHeight": 1.6,
-            },
-            "htmlFontSize": 16,
-            "overline": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.75rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.08333em",
-              "lineHeight": 2.66,
-              "textTransform": "uppercase",
-            },
-            "pxToRem": [Function],
-            "round": [Function],
-            "subtitle1": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
-              "letterSpacing": "0.00938em",
-              "lineHeight": 1.75,
-            },
-            "subtitle2": Object {
-              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-              "fontSize": "0.875rem",
-              "fontWeight": 500,
-              "letterSpacing": "0.00714em",
-              "lineHeight": 1.57,
-            },
-          },
-          "zIndex": Object {
-            "appBar": 1100,
-            "drawer": 1200,
-            "mobileStepper": 1000,
-            "modal": 1300,
-            "snackbar": 1400,
-            "speedDial": 1050,
-            "tooltip": 1500,
-          },
-        },
-        "name": "MuiBackdrop",
-      },
-      "propTypes": Object {
-        "classes": [Function],
-        "innerRef": [Function],
-      },
-      "render": [Function],
-      "useStyles": [Function],
-    }
-  }
-  BackdropProps={
-    Object {
-      "transitionDuration": Object {
-        "enter": 225,
-        "exit": 195,
-      },
-    }
-  }
   aria-label="signin credential dialog"
-  className="MuiDialog-root R3SigninCredDialog-root-1"
+  className="MuiDialog-root R3SigninCredDialog-root-1 css-1h8td7x-MuiDialog-root"
   closeAfterTransition={true}
+  components={
+    Object {
+      "Backdrop": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "__emotion_base": Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "propTypes": Object {
+            "children": [Function],
+            "className": [Function],
+            "classes": [Function],
+            "component": [Function],
+            "components": [Function],
+            "componentsProps": [Function],
+            "invisible": [Function],
+            "open": [Function],
+            "sx": [Function],
+            "transitionDuration": [Function],
+          },
+          "render": [Function],
+        },
+        "__emotion_forwardProp": [Function],
+        "__emotion_real": [Circular],
+        "__emotion_styles": Array [
+          "label:MuiDialog-backdrop;",
+          Object {
+            "zIndex": -1,
+          },
+          [Function],
+        ],
+        "defaultProps": undefined,
+        "render": [Function],
+        "withComponent": [Function],
+      },
+    }
+  }
+  componentsProps={
+    Object {
+      "backdrop": Object {
+        "as": undefined,
+        "transitionDuration": Object {
+          "enter": 225,
+          "exit": 195,
+        },
+      },
+    }
+  }
   disableEscapeKeyDown={false}
   disablePortal={true}
   label="signin-dialog"
+  onClick={[Function]}
   onClose={[Function]}
   open={true}
 >
   <
     appear={true}
     in={true}
-    role="none presentation"
+    role="presentation"
     timeout={
       Object {
         "enter": 225,
@@ -345,39 +70,34 @@ exports[`R3CreateServiceDialog test snapshot for Rr3SigninCredDialog 1`] = `
     }
   >
     <div
-      className="MuiDialog-container MuiDialog-scrollBody"
+      className="MuiDialog-container MuiDialog-scrollBody css-iz3z40-MuiDialog-container"
       onMouseDown={[Function]}
-      onMouseUp={[Function]}
     >
       <div
-        className="MuiPaper-root MuiDialog-paper MuiDialog-paperScrollBody MuiDialog-paperWidthSm MuiDialog-paperFullWidth MuiPaper-elevation24 MuiPaper-rounded"
+        className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollBody MuiDialog-paperWidthSm MuiDialog-paperFullWidth css-zfoovh-MuiPaper-root-MuiDialog-paper"
         role="dialog"
       >
-        <div
-          className="MuiDialogTitle-root R3SigninCredDialog-dialogTitle-2"
+        <h2
+          className="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root R3SigninCredDialog-dialogTitle-2 css-bdhsul-MuiTypography-root-MuiDialogTitle-root"
           label="signin-dialog"
         >
-          <h2
-            className="MuiTypography-root MuiTypography-h6"
+          <span
+            className="MuiTypography-root MuiTypography-h5 MuiTypography-noWrap R3SigninCredDialog-title-3 css-idtq1y-MuiTypography-root"
           >
-            <span
-              className="MuiTypography-root R3SigninCredDialog-title-3 MuiTypography-h5 MuiTypography-colorPrimary MuiTypography-noWrap"
-            >
-              Signin
-            </span>
-          </h2>
-        </div>
+            Signin
+          </span>
+        </h2>
         <div
-          className="MuiDialogContent-root R3SigninCredDialog-dialogContent-4"
+          className="MuiDialogContent-root R3SigninCredDialog-dialogContent-4 css-ypiqx9-MuiDialogContent-root"
         >
           <span
-            className="MuiTypography-root MuiDialogContentText-root R3SigninCredDialog-dialogContentText-5 MuiTypography-body1 MuiTypography-colorTextSecondary"
+            className="MuiDialogContentText-root MuiTypography-root MuiTypography-body1 R3SigninCredDialog-dialogContentText-5 css-qfso29-MuiTypography-root-MuiDialogContentText-root"
           />
           <div
-            className="MuiFormControl-root MuiTextField-root R3SigninCredDialog-textField-9 MuiFormControl-marginNormal MuiFormControl-fullWidth"
+            className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root R3SigninCredDialog-textField-9 css-17vbkzs-MuiFormControl-root-MuiTextField-root"
           >
             <label
-              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+              className="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-root MuiFormLabel-colorPrimary css-aqpgxn-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink={false}
               htmlFor="username-textfield-id"
               id="username-textfield-id-label"
@@ -385,13 +105,13 @@ exports[`R3CreateServiceDialog test snapshot for Rr3SigninCredDialog 1`] = `
               USER NAME(ID etc)
             </label>
             <div
-              className="MuiInputBase-root MuiInput-root MuiInput-underline R3SigninCredDialog-inputTextField-10 MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+              className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl R3SigninCredDialog-inputTextField-10 css-1a1fmpi-MuiInputBase-root-MuiInput-root"
               onClick={[Function]}
             >
               <input
                 aria-invalid={false}
                 autoFocus={false}
-                className="MuiInputBase-input MuiInput-input"
+                className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
                 disabled={false}
                 id="username-textfield-id"
                 onAnimationStart={[Function]}
@@ -406,10 +126,10 @@ exports[`R3CreateServiceDialog test snapshot for Rr3SigninCredDialog 1`] = `
             </div>
           </div>
           <div
-            className="MuiFormControl-root MuiTextField-root R3SigninCredDialog-textField-9 MuiFormControl-marginNormal MuiFormControl-fullWidth"
+            className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root R3SigninCredDialog-textField-9 css-17vbkzs-MuiFormControl-root-MuiTextField-root"
           >
             <label
-              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+              className="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-root MuiFormLabel-colorPrimary css-aqpgxn-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink={false}
               htmlFor="passphrase-textfield-id"
               id="passphrase-textfield-id-label"
@@ -417,13 +137,13 @@ exports[`R3CreateServiceDialog test snapshot for Rr3SigninCredDialog 1`] = `
               PASS PHRASE
             </label>
             <div
-              className="MuiInputBase-root MuiInput-root MuiInput-underline R3SigninCredDialog-inputTextField-10 MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+              className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd R3SigninCredDialog-inputTextField-10 css-1a1fmpi-MuiInputBase-root-MuiInput-root"
               onClick={[Function]}
             >
               <input
                 aria-invalid={false}
                 autoFocus={false}
-                className="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+                className="MuiInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd css-1x51dt5-MuiInputBase-input-MuiInput-input"
                 disabled={false}
                 id="passphrase-textfield-id"
                 onAnimationStart={[Function]}
@@ -436,14 +156,15 @@ exports[`R3CreateServiceDialog test snapshot for Rr3SigninCredDialog 1`] = `
                 value=""
               />
               <div
-                className="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                className="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-standard MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
               >
                 <button
                   aria-label="toggle passphrase visibility"
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeLarge css-1f88mc5-MuiButtonBase-root-MuiIconButton-root"
                   disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
+                  onContextMenu={[Function]}
                   onDragLeave={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -457,34 +178,32 @@ exports[`R3CreateServiceDialog test snapshot for Rr3SigninCredDialog 1`] = `
                   tabIndex={0}
                   type="button"
                 >
-                  <span
-                    className="MuiIconButton-label"
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    data-testid="VisibilityIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
-                      />
-                    </svg>
-                  </span>
+                    <path
+                      d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                    />
+                  </svg>
                 </button>
               </div>
             </div>
           </div>
         </div>
         <div
-          className="MuiDialogActions-root MuiDialogActions-spacing"
+          className="MuiDialogActions-root MuiDialogActions-spacing css-hlj6pa-MuiDialogActions-root"
         >
           <button
             aria-label="cancel"
-            className="MuiButtonBase-root MuiButton-root MuiButton-contained R3SigninCredDialog-cancelButton-11 MuiButton-containedPrimary"
+            className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root R3SigninCredDialog-cancelButton-11 css-sghohy-MuiButtonBase-root-MuiButton-root"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
+            onContextMenu={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -498,28 +217,26 @@ exports[`R3CreateServiceDialog test snapshot for Rr3SigninCredDialog 1`] = `
             tabIndex={0}
             type="button"
           >
-            <span
-              className="MuiButton-label"
+            CANCEL
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3SigninCredDialog-buttonIcon-13 css-i4bv87-MuiSvgIcon-root"
+              data-testid="CancelIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              CANCEL
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root R3SigninCredDialog-buttonIcon-13"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
-                />
-              </svg>
-            </span>
+              <path
+                d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+              />
+            </svg>
           </button>
           <button
             aria-label="sign in"
-            className="MuiButtonBase-root MuiButton-root MuiButton-contained R3SigninCredDialog-signinButton-12 MuiButton-containedSecondary Mui-disabled Mui-disabled"
+            className="MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root Mui-disabled R3SigninCredDialog-signinButton-12 css-zcbmsk-MuiButtonBase-root-MuiButton-root"
             disabled={true}
             onBlur={[Function]}
             onClick={[Function]}
+            onContextMenu={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -533,21 +250,18 @@ exports[`R3CreateServiceDialog test snapshot for Rr3SigninCredDialog 1`] = `
             tabIndex={-1}
             type="button"
           >
-            <span
-              className="MuiButton-label"
+            SGIN IN
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3SigninCredDialog-buttonIcon-13 css-i4bv87-MuiSvgIcon-root"
+              data-testid="CheckCircleIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              SGIN IN
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root R3SigninCredDialog-buttonIcon-13"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                />
-              </svg>
-            </span>
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+              />
+            </svg>
           </button>
         </div>
       </div>

--- a/test/__tests__/__snapshots__/r3toolbar-test.jsx.snap
+++ b/test/__tests__/__snapshots__/r3toolbar-test.jsx.snap
@@ -3,17 +3,19 @@
 exports[`R3ToolBar test snapshot for R3ToolBar 1`] = `
 <div>
   <header
-    className="MuiPaper-root MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary R3Toolbar-root-1 MuiPaper-elevation0"
+    className="MuiPaper-root MuiPaper-elevation MuiPaper-elevation0 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionStatic R3Toolbar-root-1 css-120r8wl-MuiPaper-root-MuiAppBar-root"
   >
     <div
-      className="MuiToolbar-root MuiToolbar-regular R3Toolbar-toolbar-2 MuiToolbar-gutters"
+      className="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular R3Toolbar-toolbar-2 css-hyum1k-MuiToolbar-root"
     >
       <div
-        aria-describedby={null}
         aria-label="current display item and its path"
-        className="MuiButtonBase-root MuiChip-root R3Toolbar-chip-4 MuiChip-colorPrimary MuiChip-clickableColorPrimary MuiChip-clickable"
+        aria-labelledby={null}
+        className="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary R3Toolbar-chip-4 css-799jnf-MuiButtonBase-root-MuiChip-root"
+        data-mui-internal-clone-element={true}
         onBlur={[Function]}
         onClick={[Function]}
+        onContextMenu={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -28,14 +30,14 @@ exports[`R3ToolBar test snapshot for R3ToolBar 1`] = `
         onTouchStart={[Function]}
         role="button"
         tabIndex={0}
-        title="Display path information"
       >
         <div
-          className="MuiAvatar-root MuiAvatar-circular MuiChip-avatar R3Toolbar-avatar-7 MuiChip-avatarColorPrimary MuiAvatar-colorDefault"
+          className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault R3Toolbar-avatar-7 css-2s90m6-MuiAvatar-root"
         >
           <svg
             aria-hidden={true}
-            className="MuiSvgIcon-root R3Toolbar-descriptionIcon-8"
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium R3Toolbar-descriptionIcon-8 css-i4bv87-MuiSvgIcon-root"
+            data-testid="DescriptionIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -45,29 +47,32 @@ exports[`R3ToolBar test snapshot for R3ToolBar 1`] = `
           </svg>
         </div>
         <span
-          className="MuiChip-label"
+          className="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
         >
           <span
-            className="MuiTypography-root R3Toolbar-chipText-5 MuiTypography-subtitle2"
+            className="MuiTypography-root MuiTypography-subtitle2 R3Toolbar-chipText-5 css-1sr7afs-MuiTypography-root"
           >
             SERVICE
           </span>
         </span>
         <span
-          className="MuiTouchRipple-root"
+          className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
       </div>
       <span
-        className="MuiTypography-root R3Toolbar-title-3 MuiTypography-subtitle2 MuiTypography-colorTextSecondary MuiTypography-noWrap"
+        className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap R3Toolbar-title-3 css-k76d41-MuiTypography-root"
       >
         .../dummyresource
       </span>
       <button
-        aria-describedby={null}
-        className="MuiButtonBase-root MuiIconButton-root"
+        aria-label="Move to upper path"
+        aria-labelledby={null}
+        className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-mui-internal-clone-element={true}
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
+        onContextMenu={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -81,36 +86,35 @@ exports[`R3ToolBar test snapshot for R3ToolBar 1`] = `
         onTouchMove={[Function]}
         onTouchStart={[Function]}
         tabIndex={0}
-        title="Move to upper path"
         type="button"
       >
-        <span
-          className="MuiIconButton-label"
+        <svg
+          aria-hidden={true}
+          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          data-testid="ArrowUpwardRoundedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
         >
-          <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M13 19V7.83l4.88 4.88c.39.39 1.03.39 1.42 0 .39-.39.39-1.02 0-1.41l-6.59-6.59a.9959.9959 0 00-1.41 0l-6.6 6.58c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L11 7.83V19c0 .55.45 1 1 1s1-.45 1-1z"
-            />
-          </svg>
-        </span>
+          <path
+            d="M13 19V7.83l4.88 4.88c.39.39 1.03.39 1.42 0 .39-.39.39-1.02 0-1.41l-6.59-6.59a.9959.9959 0 0 0-1.41 0l-6.6 6.58c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L11 7.83V19c0 .55.45 1 1 1s1-.45 1-1z"
+          />
+        </svg>
         <span
-          className="MuiTouchRipple-root"
+          className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
       </button>
       <div
         className="R3Toolbar-spacerInToolbar-9"
       />
       <button
-        aria-describedby={null}
-        className="MuiButtonBase-root MuiIconButton-root"
+        aria-label="Create SERVICE under TENANT"
+        aria-labelledby={null}
+        className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-mui-internal-clone-element={true}
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
+        onContextMenu={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -124,33 +128,32 @@ exports[`R3ToolBar test snapshot for R3ToolBar 1`] = `
         onTouchMove={[Function]}
         onTouchStart={[Function]}
         tabIndex={0}
-        title="Create SERVICE under TENANT"
         type="button"
       >
-        <span
-          className="MuiIconButton-label"
+        <svg
+          aria-hidden={true}
+          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          data-testid="AddRoundedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
         >
-          <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
-            />
-          </svg>
-        </span>
+          <path
+            d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
+          />
+        </svg>
         <span
-          className="MuiTouchRipple-root"
+          className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
       </button>
       <button
-        aria-describedby={null}
-        className="MuiButtonBase-root MuiIconButton-root"
+        aria-label="Delete SERVICE under TENANT"
+        aria-labelledby={null}
+        className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-mui-internal-clone-element={true}
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
+        onContextMenu={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -164,25 +167,21 @@ exports[`R3ToolBar test snapshot for R3ToolBar 1`] = `
         onTouchMove={[Function]}
         onTouchStart={[Function]}
         tabIndex={0}
-        title="Delete SERVICE under TENANT"
         type="button"
       >
-        <span
-          className="MuiIconButton-label"
+        <svg
+          aria-hidden={true}
+          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          data-testid="ClearRoundedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
         >
-          <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
-            />
-          </svg>
-        </span>
+          <path
+            d="M18.3 5.71a.9959.9959 0 0 0-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 0 0-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+          />
+        </svg>
         <span
-          className="MuiTouchRipple-root"
+          className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
       </button>
     </div>

--- a/test/__tests__/r3aboutdialog-test.jsx
+++ b/test/__tests__/r3aboutdialog-test.jsx
@@ -22,8 +22,8 @@
 import React					from 'react';										// eslint-disable-line no-unused-vars
 import renderer					from 'react-test-renderer';
 import getElementWithContext	from 'react-test-context-provider';					// for context provider
-import { ThemeProvider }		from '@material-ui/styles';							// for custom theme
-import CssBaseline				from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }		from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';					// for jss and reset.css
 
 import r3Theme					from '../../src/components/r3theme';				// custom theme
 import R3AboutDialog			from '../../src/components/r3aboutdialog';
@@ -76,10 +76,10 @@ r3Theme.r3AboutDialog.root['disablePortal'] = true;
 // Unlike before, by changing the mock content, you can fully check
 // the snapshots in the Dialog.
 //
-jest.mock('@material-ui/core/Fade', () => {												// eslint-disable-line no-undef
+jest.mock('@mui/material/Fade', () => {												// eslint-disable-line no-undef
 	return '';
 });
-jest.mock('@material-ui/core/Modal', () => {											// eslint-disable-line no-undef
+jest.mock('@mui/material/Modal', () => {											// eslint-disable-line no-undef
 	return '';
 });
 
@@ -111,21 +111,23 @@ describe('R3AboutDialog', () => {													// eslint-disable-line no-undef
 	});
 
 	it('test snapshot for R3AboutDialog', () => {									// eslint-disable-line no-undef
-		/* eslint-disable indent */
 		const r3provider	= new R3Provider(null);
-		const element		= getElementWithContext({
-									r3Context:	r3provider.getR3Context()
-								},
-								<ThemeProvider theme={ r3Theme } >
-									<CssBaseline />
-									<R3AboutDialog
-										r3provider={ r3provider }
-										open={ true }
-										onClose={ close }
-									/>
-								</ThemeProvider>
-							);
-		/* eslint-enable indent */
+
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3AboutDialog
+						r3provider={ r3provider }
+						open={ true }
+						onClose={ close }
+					/>
+				</ThemeProvider>
+			</StyledEngineProvider>
+		);
 
 		const component = renderer.create(element, { createNodeMock });
 		let tree		= component.toJSON();

--- a/test/__tests__/r3accountdialog-test.jsx
+++ b/test/__tests__/r3accountdialog-test.jsx
@@ -22,8 +22,8 @@
 import React					from 'react';										// eslint-disable-line no-unused-vars
 import renderer					from 'react-test-renderer';
 import getElementWithContext	from 'react-test-context-provider';					// for context provider
-import { ThemeProvider }		from '@material-ui/styles';							// for custom theme
-import CssBaseline				from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }		from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';					// for jss and reset.css
 
 import r3Theme					from '../../src/components/r3theme';				// custom theme
 import R3AccountDialog			from '../../src/components/r3accountdialog';
@@ -64,7 +64,7 @@ const mockCreatePortal = jest.fn((element, node) => {								// eslint-disable-l
 // This error can be avoided by setting the disablePortal property of
 // the Dialog class to true.
 //
-r3Theme.r3PathInfoDialog.root['disablePortal'] = true;
+r3Theme.r3AccountDialog.root['disablePortal'] = true;
 
 // [NOTE]
 // The Transition class used in this dialog is Fade.
@@ -76,10 +76,10 @@ r3Theme.r3PathInfoDialog.root['disablePortal'] = true;
 // Unlike before, by changing the mock content, you can fully check
 // the snapshots in the Dialog.
 //
-jest.mock('@material-ui/core/Fade', () => {												// eslint-disable-line no-undef
+jest.mock('@mui/material/Fade', () => {												// eslint-disable-line no-undef
 	return '';
 });
-jest.mock('@material-ui/core/Modal', () => {											// eslint-disable-line no-undef
+jest.mock('@mui/material/Modal', () => {											// eslint-disable-line no-undef
 	return '';
 });
 
@@ -111,23 +111,25 @@ describe('R3AccountDialog', () => {													// eslint-disable-line no-undef
 	});
 
 	it('test snapshot for R3AccountDialog', () => {									// eslint-disable-line no-undef
-		/* eslint-disable indent */
 		const r3provider	= new R3Provider(null);
-		const element		= getElementWithContext({
-									r3Context:	r3provider.getR3Context()
-								},
-								<ThemeProvider theme={ r3Theme } >
-									<CssBaseline />
-									<R3AccountDialog
-										r3provider={ r3provider }
-										open={ true }
-										username={ 'JEST_TEST_USERNAME' }
-										unscopedtoken={ 'JEST_TEST_UNSCOPED_TOKEN' }
-										onClose={ close }
-									/>
-								</ThemeProvider>
-							);
-		/* eslint-enable indent */
+
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3AccountDialog
+						r3provider={ r3provider }
+						open={ true }
+						username={ 'JEST_TEST_USERNAME' }
+						unscopedtoken={ 'JEST_TEST_UNSCOPED_TOKEN' }
+						onClose={ close }
+					/>
+				</ThemeProvider>
+			</StyledEngineProvider>
+		);
 
 		const component = renderer.create(element, { createNodeMock });
 		let tree		= component.toJSON();

--- a/test/__tests__/r3appbar-test.jsx
+++ b/test/__tests__/r3appbar-test.jsx
@@ -22,8 +22,8 @@
 import React					from 'react';										// eslint-disable-line no-unused-vars
 import renderer					from 'react-test-renderer';
 import getElementWithContext	from 'react-test-context-provider';					// for context provider
-import { ThemeProvider }		from '@material-ui/styles';							// for custom theme
-import CssBaseline				from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }		from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';					// for jss and reset.css
 
 import r3Theme					from '../../src/components/r3theme';				// custom theme
 import R3AppBar					from '../../src/components/r3appbar';
@@ -57,28 +57,30 @@ const account		= jest.fn();										// eslint-disable-line no-undef
 //
 describe('R3AppBar', () => {											// eslint-disable-line no-undef
 	it('test snapshot for R3AppBar', () => {							// eslint-disable-line no-undef
-		/* eslint-disable indent */
 		const r3provider	= new R3Provider(null);
-		const element		= getElementWithContext({
-									r3Context:	r3provider.getR3Context()
-								},
-								<ThemeProvider theme={ r3Theme } >
-									<CssBaseline />
-									<R3AppBar
-										r3provider={ r3provider }
-										title='K2HR3'
-										enDock={ false }
-										isDocking={ true }
-										onTreeDetach={ treedetach }
-										onOpenTree={ opentree }
-										onCheckUpdating={ checkupdating }
-										onAbout={ about }
-										onSign={ sign }
-										onAccount={ account }
-									/>
-								</ThemeProvider>
-							);
-		/* eslint-enable indent */
+
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3AppBar
+						r3provider={ r3provider }
+						title='K2HR3'
+						enDock={ false }
+						isDocking={ true }
+						onTreeDetach={ treedetach }
+						onOpenTree={ opentree }
+						onCheckUpdating={ checkupdating }
+						onAbout={ about }
+						onSign={ sign }
+						onAccount={ account }
+					/>
+				</ThemeProvider>
+			</StyledEngineProvider>
+		);
 
 		const component = renderer.create(element, { createNodeMock });
 		let tree		= component.toJSON();

--- a/test/__tests__/r3container-test.jsx
+++ b/test/__tests__/r3container-test.jsx
@@ -19,29 +19,38 @@
  *
  */
 
-import React				from 'react';										// eslint-disable-line no-unused-vars
-import R3Container			from '../../src/components/r3container';
-import renderer				from 'react-test-renderer';
-import { ThemeProvider }	from '@material-ui/styles';							// for custom theme
-import CssBaseline			from '@material-ui/core/CssBaseline';				// for reset.css
+import React					from 'react';									// eslint-disable-line no-unused-vars
+import renderer					from 'react-test-renderer';
+import getElementWithContext	from 'react-test-context-provider';				// for context provider
+import { ThemeProvider }		from '@mui/styles';								// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';				// for jss and reset.css
 
-import r3Theme				from '../../src/components/r3theme';				// custom theme
+import r3Theme					from '../../src/components/r3theme';			// custom theme
+import R3Container				from '../../src/components/r3container';
+import R3Provider				from '../../src/util/r3provider';
 
-import mock_fetch			from '../__mocks__/fetchMock';						// eslint-disable-line no-unused-vars
-import { createNodeMock }	from '../__mocks__/materialUiMock';					// for material-ui
+import mock_fetch				from '../__mocks__/fetchMock';					// eslint-disable-line no-unused-vars
+import { createNodeMock }		from '../__mocks__/materialUiMock';				// for material-ui
 
 describe('R3Container', () => {										// eslint-disable-line no-undef
 	it('test snapshot for R3Container', () => {						// eslint-disable-line no-undef
-		const component = renderer.create(
-			<ThemeProvider theme={ r3Theme } >
-				<CssBaseline />
-				<R3Container
-					title='K2HR3'
-				/>
-			</ThemeProvider>,
-			{ createNodeMock }
+		const r3provider	= new R3Provider(null);
+
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3Container
+						title='K2HR3'
+					/>
+				</ThemeProvider>
+			</StyledEngineProvider>
 		);
 
+		const component = renderer.create(element, { createNodeMock });
 		let	tree = component.toJSON();
 		expect(tree).toMatchSnapshot();								// eslint-disable-line no-undef
 	});

--- a/test/__tests__/r3createpathdialog-test.jsx
+++ b/test/__tests__/r3createpathdialog-test.jsx
@@ -22,8 +22,8 @@
 import React					from 'react';										// eslint-disable-line no-unused-vars
 import renderer					from 'react-test-renderer';
 import getElementWithContext	from 'react-test-context-provider';					// for context provider
-import { ThemeProvider }		from '@material-ui/styles';							// for custom theme
-import CssBaseline				from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }		from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';					// for jss and reset.css
 
 import r3Theme					from '../../src/components/r3theme';				// custom theme
 import R3CreatePathDialog		from '../../src/components/r3createpathdialog';
@@ -76,10 +76,10 @@ r3Theme.r3CreatePathDialog.root['disablePortal'] = true;
 // Unlike before, by changing the mock content, you can fully check
 // the snapshots in the Dialog.
 //
-jest.mock('@material-ui/core/Fade', () => {												// eslint-disable-line no-undef
+jest.mock('@mui/material/Fade', () => {												// eslint-disable-line no-undef
 	return '';
 });
-jest.mock('@material-ui/core/Modal', () => {											// eslint-disable-line no-undef
+jest.mock('@mui/material/Modal', () => {											// eslint-disable-line no-undef
 	return '';
 });
 
@@ -120,29 +120,30 @@ describe('R3CreatePathDialog', () => {												// eslint-disable-line no-unde
 	});
 
 	it('test snapshot for R3CreatePathDialog', () => {								// eslint-disable-line no-undef
-		/* eslint-disable indent */
 		const r3provider	= new R3Provider(null);
 
 		// [NOTE]
 		// We need <div> for Dialog
 		//
-		const element		= getElementWithContext({
-									r3Context:	r3provider.getR3Context()
-								},
-								<ThemeProvider theme={ r3Theme } >
-									<CssBaseline />
-									<R3CreatePathDialog
-										r3provider={ r3provider }
-										open={ true }
-										tenant={ tenant }
-										type={ 'role' }
-										parentPath={ '/JEST_ROLE_PARENT_PATH' }
-										newPath={ '' }
-										onClose={ close }
-									/>
-								</ThemeProvider>
-							);
-		/* eslint-enable indent */
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3CreatePathDialog
+						r3provider={ r3provider }
+						open={ true }
+						tenant={ tenant }
+						type={ 'role' }
+						parentPath={ '/JEST_ROLE_PARENT_PATH' }
+						newPath={ '' }
+						onClose={ close }
+					/>
+				</ThemeProvider>
+			</StyledEngineProvider>
+		);
 
 		const component = renderer.create(element, { createNodeMock });
 		let tree		= component.toJSON();

--- a/test/__tests__/r3createservicedialog-test.jsx
+++ b/test/__tests__/r3createservicedialog-test.jsx
@@ -22,8 +22,8 @@
 import React					from 'react';										// eslint-disable-line no-unused-vars
 import renderer					from 'react-test-renderer';
 import getElementWithContext	from 'react-test-context-provider';					// for context provider
-import { ThemeProvider }		from '@material-ui/styles';							// for custom theme
-import CssBaseline				from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }		from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';					// for jss and reset.css
 
 import r3Theme					from '../../src/components/r3theme';				// custom theme
 import R3CreateServiceDialog	from '../../src/components/r3createservicedialog';
@@ -76,10 +76,10 @@ r3Theme.r3CreateServiceDialog.root['disablePortal'] = true;
 // Unlike before, by changing the mock content, you can fully check
 // the snapshots in the Dialog.
 //
-jest.mock('@material-ui/core/Fade', () => {												// eslint-disable-line no-undef
+jest.mock('@mui/material/Fade', () => {												// eslint-disable-line no-undef
 	return '';
 });
-jest.mock('@material-ui/core/Modal', () => {											// eslint-disable-line no-undef
+jest.mock('@mui/material/Modal', () => {											// eslint-disable-line no-undef
 	return '';
 });
 
@@ -119,25 +119,27 @@ describe('R3CreateServiceDialog', () => {											// eslint-disable-line no-un
 	});
 
 	it('test snapshot for R3CreateServiceDialog', () => {							// eslint-disable-line no-undef
-		/* eslint-disable indent */
 		const r3provider	= new R3Provider(null);
-		const element		= getElementWithContext({
-									r3Context:	r3provider.getR3Context()
-								},
-								<ThemeProvider theme={ r3Theme } >
-									<CssBaseline />
-									<R3CreateServiceDialog
-										r3provider={ r3provider }
-										open={ true }
-										createMode={ true }
-										tenant={ tenant }
-										newServiceName={ '' }
-										newVerify={ '' }
-										onClose={ close }
-									/>
-								</ThemeProvider>
-							);
-		/* eslint-enable indent */
+
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3CreateServiceDialog
+						r3provider={ r3provider }
+						open={ true }
+						createMode={ true }
+						tenant={ tenant }
+						newServiceName={ '' }
+						newVerify={ '' }
+						onClose={ close }
+					/>
+				</ThemeProvider>
+			</StyledEngineProvider>
+		);
 
 		const component = renderer.create(element, { createNodeMock });
 		let tree		= component.toJSON();

--- a/test/__tests__/r3createservicetenantdialog-test.jsx
+++ b/test/__tests__/r3createservicetenantdialog-test.jsx
@@ -22,8 +22,8 @@
 import React						from 'react';										// eslint-disable-line no-unused-vars
 import renderer						from 'react-test-renderer';
 import getElementWithContext		from 'react-test-context-provider';					// for context provider
-import { ThemeProvider }			from '@material-ui/styles';							// for custom theme
-import CssBaseline					from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }			from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';						// for jss and reset.css
 
 import r3Theme						from '../../src/components/r3theme';				// custom theme
 import R3CreateServiceTenantDialog	from '../../src/components/r3createservicetenantdialog';
@@ -79,10 +79,10 @@ r3Theme.r3CreateServiceTenantDialog.root['disablePortal'] = true;
 // Unlike before, by changing the mock content, you can fully check
 // the snapshots in the Dialog.
 //
-jest.mock('@material-ui/core/Fade', () => {												// eslint-disable-line no-undef
+jest.mock('@mui/material/Fade', () => {												// eslint-disable-line no-undef
 	return '';
 });
-jest.mock('@material-ui/core/Modal', () => {											// eslint-disable-line no-undef
+jest.mock('@mui/material/Modal', () => {											// eslint-disable-line no-undef
 	return '';
 });
 
@@ -122,24 +122,26 @@ describe('R3CreateServiceTenantDialog', () => {										// eslint-disable-line 
 	});
 
 	it('test snapshot for R3CreateServiceTenantDialog', () => {						// eslint-disable-line no-undef
-		/* eslint-disable indent */
 		const r3provider	= new R3Provider(null);
-		const element		= getElementWithContext({
-									r3Context:	r3provider.getR3Context()
-								},
-								<ThemeProvider theme={ r3Theme } >
-									<CssBaseline />
-									<R3CreateServiceTenantDialog
-										r3provider={ r3provider }
-										open={ true }
-										tenant={ tenant }
-										service={ 'JEST_OWNER_SERVICE_NAME' }
-										aliasRole={ '' }
-										onClose={ close }
-									/>
-								</ThemeProvider>
-							);
-		/* eslint-enable indent */
+
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3CreateServiceTenantDialog
+						r3provider={ r3provider }
+						open={ true }
+						tenant={ tenant }
+						service={ 'JEST_OWNER_SERVICE_NAME' }
+						aliasRole={ '' }
+						onClose={ close }
+					/>
+				</ThemeProvider>
+			</StyledEngineProvider>
+		);
 
 		const component = renderer.create(element, { createNodeMock });
 		let tree		= component.toJSON();

--- a/test/__tests__/r3formbuttons-test.jsx
+++ b/test/__tests__/r3formbuttons-test.jsx
@@ -22,8 +22,8 @@
 import React					from 'react';										// eslint-disable-line no-unused-vars
 import renderer					from 'react-test-renderer';
 import getElementWithContext	from 'react-test-context-provider';					// for context provider
-import { ThemeProvider }		from '@material-ui/styles';							// for custom theme
-import CssBaseline				from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }		from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';					// for jss and reset.css
 
 import r3Theme					from '../../src/components/r3theme';				// custom theme
 import R3FormButtons			from '../../src/components/r3formbuttons';
@@ -53,22 +53,24 @@ const save		= jest.fn();											// eslint-disable-line no-undef
 //
 describe('R3FormButtons', () => {										// eslint-disable-line no-undef
 	it('test snapshot for R3FormButtons', () => {						// eslint-disable-line no-undef
-		/* eslint-disable indent */
 		const r3provider	= new R3Provider(null);
-		const element		= getElementWithContext({
-									r3Context:	r3provider.getR3Context()
-								},
-								<ThemeProvider theme={ r3Theme } >
-									<CssBaseline />
-									<R3FormButtons
-										r3provider={ r3provider }
-										status={ true }
-										onSave={ save }
-										onCancel={ cancel }
-									/>
-								</ThemeProvider>
-							);
-		/* eslint-enable indent */
+
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3FormButtons
+						r3provider={ r3provider }
+						status={ true }
+						onSave={ save }
+						onCancel={ cancel }
+					/>
+				</ThemeProvider>
+			</StyledEngineProvider>
+		);
 
 		const component = renderer.create(element, { createNodeMock });
 		let tree		= component.toJSON();

--- a/test/__tests__/r3maintree-test.jsx
+++ b/test/__tests__/r3maintree-test.jsx
@@ -22,8 +22,8 @@
 import React					from 'react';										// eslint-disable-line no-unused-vars
 import renderer					from 'react-test-renderer';
 import getElementWithContext	from 'react-test-context-provider';					// for context provider
-import { ThemeProvider }		from '@material-ui/styles';							// for custom theme
-import CssBaseline				from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }		from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';					// for jss and reset.css
 
 import r3Theme					from '../../src/components/r3theme';				// custom theme
 import R3MainTree				from '../../src/components/r3maintree';
@@ -177,40 +177,42 @@ const selectedpath		= 'service:child_service:resource:dummyserviceresource';
 //
 describe('R3MainTree', () => {											// eslint-disable-line no-undef
 	it('test snapshot for R3MainTree', () => {							// eslint-disable-line no-undef
-		/* eslint-disable indent */
 		const r3provider	= new R3Provider(null);
-		const element		= getElementWithContext({
-									r3Context:	r3provider.getR3Context()
-								},
-								<ThemeProvider theme={ r3Theme } >
-									<CssBaseline />
-									<R3MainTree
-										r3provider={ r3provider }
-										title='K2HR3'
-										enDock={ false }
-										isDocking={ true }
-										open={ true }
-										tenants={ tenants }
-										treeList={ treelist }
-										selectedTenant={ tenants[0] }
-										selectedType={ selectedtype }
-										selectedService={ selectedservice }
-										selectedPath={ selectedpath }
-										onTenantChange={ TenantChange }
-										onTypeItemChange={ TypeItemChange }
-										onListItemChange={ ListItemChange }
-										onNameItemInServiceChange={ NameItemInServiceChange }
-										onTypeInServiceChange={ TypeInServiceChange }
-										onListItemInServiceChange={ ListItemInServiceChange }
-										onOpenChange={ OpenChange }
-										onPopupClose={ PopupClose }
-										onTreeDocking={ TreeDocking }
-										onCheckUpdating={ CheckUpdating }
-										onAbout={ About }
-									/>
-								</ThemeProvider>
-							);
-		/* eslint-enable indent */
+
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3MainTree
+						r3provider={ r3provider }
+						title='K2HR3'
+						enDock={ false }
+						isDocking={ true }
+						open={ true }
+						tenants={ tenants }
+						treeList={ treelist }
+						selectedTenant={ tenants[0] }
+						selectedType={ selectedtype }
+						selectedService={ selectedservice }
+						selectedPath={ selectedpath }
+						onTenantChange={ TenantChange }
+						onTypeItemChange={ TypeItemChange }
+						onListItemChange={ ListItemChange }
+						onNameItemInServiceChange={ NameItemInServiceChange }
+						onTypeInServiceChange={ TypeInServiceChange }
+						onListItemInServiceChange={ ListItemInServiceChange }
+						onOpenChange={ OpenChange }
+						onPopupClose={ PopupClose }
+						onTreeDocking={ TreeDocking }
+						onCheckUpdating={ CheckUpdating }
+						onAbout={ About }
+					/>
+				</ThemeProvider>
+			</StyledEngineProvider>
+		);
 
 		const component = renderer.create(element, { createNodeMock });
 		let tree		= component.toJSON();

--- a/test/__tests__/r3msgbox-test.jsx
+++ b/test/__tests__/r3msgbox-test.jsx
@@ -22,8 +22,8 @@
 import React					from 'react';										// eslint-disable-line no-unused-vars
 import renderer					from 'react-test-renderer';
 import getElementWithContext	from 'react-test-context-provider';					// for context provider
-import { ThemeProvider }		from '@material-ui/styles';							// for custom theme
-import CssBaseline				from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }		from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';					// for jss and reset.css
 
 import r3Theme					from '../../src/components/r3theme';				// custom theme
 import R3MsgBox					from '../../src/components/r3msgbox';
@@ -44,19 +44,21 @@ const message = new R3Message('Dummy error message', errorType);
 //
 describe('R3MsgBox', () => {											// eslint-disable-line no-undef
 	it('test snapshot for R3MsgBox', () => {							// eslint-disable-line no-undef
-		/* eslint-disable indent */
 		const r3provider	= new R3Provider(null);
-		const element		= getElementWithContext({
-									r3Context:	r3provider.getR3Context()
-								},
-								<ThemeProvider theme={ r3Theme } >
-									<CssBaseline />
-									<R3MsgBox
-										message={ message }
-									/>
-								</ThemeProvider>
-							);
-		/* eslint-enable indent */
+
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3MsgBox
+						message={ message }
+					/>
+				</ThemeProvider>
+			</StyledEngineProvider>
+		);
 
 		const component = renderer.create(element, { createNodeMock });
 		let tree		= component.toJSON();

--- a/test/__tests__/r3pathinfodialog-test.jsx
+++ b/test/__tests__/r3pathinfodialog-test.jsx
@@ -22,8 +22,8 @@
 import React					from 'react';										// eslint-disable-line no-unused-vars
 import renderer					from 'react-test-renderer';
 import getElementWithContext	from 'react-test-context-provider';					// for context provider
-import { ThemeProvider }		from '@material-ui/styles';							// for custom theme
-import CssBaseline				from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }		from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';					// for jss and reset.css
 
 import r3Theme					from '../../src/components/r3theme';				// custom theme
 import R3PathInfoDialog			from '../../src/components/r3pathinfodialog';
@@ -76,10 +76,10 @@ r3Theme.r3PathInfoDialog.root['disablePortal'] = true;
 // Unlike before, by changing the mock content, you can fully check
 // the snapshots in the Dialog.
 //
-jest.mock('@material-ui/core/Fade', () => {												// eslint-disable-line no-undef
+jest.mock('@mui/material/Fade', () => {												// eslint-disable-line no-undef
 	return '';
 });
-jest.mock('@material-ui/core/Modal', () => {											// eslint-disable-line no-undef
+jest.mock('@mui/material/Modal', () => {											// eslint-disable-line no-undef
 	return '';
 });
 
@@ -119,27 +119,29 @@ describe('R3PathInfoDialog', () => {												// eslint-disable-line no-undef
 	});
 
 	it('test snapshot for R3PathInfoDialog', () => {								// eslint-disable-line no-undef
-		/* eslint-disable indent */
 		const r3provider	= new R3Provider(null);
-		const element		= getElementWithContext({
-									r3Context:	r3provider.getR3Context()
-								},
-								<ThemeProvider theme={ r3Theme } >
-									<CssBaseline />
-									<R3PathInfoDialog
-										r3provider={ r3provider }
-										open={ true }
-										tenant={ tenant }
-										service={ '' }
-										type={ 'role' }
-										fullpath={ 'yrn:yahoo:::37146:role:JEST_OWNER_SERVICE' }
-										userDataScript={ "#!/bin/sh\ncurl -s -S -v -X PUT -H \"x-auth-token: R=JEST_TEST_ROLE_TOKEN\" \"http://localhost:3000/v1/role/JEST_OWNER_SERVICE\"" }	// eslint-disable-line quotes
-										roleToken={ 'JEST_TEST_ROLE_TOKEN' }
-										onClose={ close }
-									/>
-								</ThemeProvider>
-							);
-		/* eslint-enable indent */
+
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3PathInfoDialog
+						r3provider={ r3provider }
+						open={ true }
+						tenant={ tenant }
+						service={ '' }
+						type={ 'role' }
+						fullpath={ 'yrn:yahoo:::37146:role:JEST_OWNER_SERVICE' }
+						userDataScript={ "#!/bin/sh\ncurl -s -S -v -X PUT -H \"x-auth-token: R=JEST_TEST_ROLE_TOKEN\" \"http://localhost:3000/v1/role/JEST_OWNER_SERVICE\"" }	// eslint-disable-line quotes
+						roleToken={ 'JEST_TEST_ROLE_TOKEN' }
+						onClose={ close }
+					/>
+				</ThemeProvider>
+			</StyledEngineProvider>
+		);
 
 		const component = renderer.create(element, { createNodeMock });
 		let tree		= component.toJSON();

--- a/test/__tests__/r3policy-test.jsx
+++ b/test/__tests__/r3policy-test.jsx
@@ -22,8 +22,8 @@
 import React					from 'react';										// eslint-disable-line no-unused-vars
 import renderer					from 'react-test-renderer';
 import getElementWithContext	from 'react-test-context-provider';					// for context provider
-import { ThemeProvider }		from '@material-ui/styles';							// for custom theme
-import CssBaseline				from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }		from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';					// for jss and reset.css
 
 import r3Theme					from '../../src/components/r3theme';				// custom theme
 import R3Policy					from '../../src/components/r3policy';
@@ -85,26 +85,27 @@ describe('R3Policy', () => {											// eslint-disable-line no-undef
 		// as true if undefined, but it must be false when using JEST. For that, autoWidth is
 		// defined in the property of R3Policy, and in this test it is set to false.
 		//
-
-		/* eslint-disable indent */
 		const r3provider	= new R3Provider(null);
-		const element		= getElementWithContext({
-									r3Context:	r3provider.getR3Context()
-								},
-								<ThemeProvider theme={ r3Theme } >
-									<CssBaseline />
-									<R3Policy
-										r3provider={ r3provider }
-										policy={ policy }
-										dispUnique={ 1 }
-										onSave={ save }
-										onUpdate={ update }
-										isReadMode={ false }
-										autoWidth={ false }
-									/>
-								</ThemeProvider>
-							);
-		/* eslint-enable indent */
+
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3Policy
+						r3provider={ r3provider }
+						policy={ policy }
+						dispUnique={ 1 }
+						onSave={ save }
+						onUpdate={ update }
+						isReadMode={ false }
+						autoWidth={ false }
+					/>
+				</ThemeProvider>
+			</StyledEngineProvider>
+		);
 
 		const component = renderer.create(element, { createNodeMock });
 		let tree		= component.toJSON();

--- a/test/__tests__/r3popupmsgdialog-test.jsx
+++ b/test/__tests__/r3popupmsgdialog-test.jsx
@@ -22,8 +22,8 @@
 import React					from 'react';										// eslint-disable-line no-unused-vars
 import renderer					from 'react-test-renderer';
 import getElementWithContext	from 'react-test-context-provider';					// for context provider
-import { ThemeProvider }		from '@material-ui/styles';							// for custom theme
-import CssBaseline				from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }		from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';					// for jss and reset.css
 
 import r3Theme					from '../../src/components/r3theme';				// custom theme
 import R3PopupMsgDialog			from '../../src/components/r3popupmsgdialog';
@@ -78,10 +78,10 @@ r3Theme.r3PopupMsgDialog.root['disablePortal'] = true;
 // Unlike before, by changing the mock content, you can fully check
 // the snapshots in the Dialog.
 //
-jest.mock('@material-ui/core/Fade', () => {												// eslint-disable-line no-undef
+jest.mock('@mui/material/Fade', () => {												// eslint-disable-line no-undef
 	return '';
 });
-jest.mock('@material-ui/core/Modal', () => {											// eslint-disable-line no-undef
+jest.mock('@mui/material/Modal', () => {											// eslint-disable-line no-undef
 	return '';
 });
 
@@ -118,23 +118,25 @@ describe('R3PopupMsgDialog', () => {												// eslint-disable-line no-undef
 	});
 
 	it('test snapshot for R3PopupMsgDialog', () => {								// eslint-disable-line no-undef
-		/* eslint-disable indent */
 		const r3provider	= new R3Provider(null);
-		const element		= getElementWithContext({
-									r3Context:	r3provider.getR3Context()
-								},
-								<ThemeProvider theme={ r3Theme } >
-									<CssBaseline />
-									<R3PopupMsgDialog
-										r3provider={ r3provider }
-										title={ 'MESSAGE FROM JEST TEST' }
-										r3Message={ message }
-										twoButton={ true }
-										onClose={ close }
-									/>
-								</ThemeProvider>
-							);
-		/* eslint-enable indent */
+
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3PopupMsgDialog
+						r3provider={ r3provider }
+						title={ 'MESSAGE FROM JEST TEST' }
+						r3Message={ message }
+						twoButton={ true }
+						onClose={ close }
+					/>
+				</ThemeProvider>
+			</StyledEngineProvider>
+		);
 
 		const component = renderer.create(element, { createNodeMock });
 		let tree		= component.toJSON();

--- a/test/__tests__/r3progress-test.jsx
+++ b/test/__tests__/r3progress-test.jsx
@@ -22,8 +22,8 @@
 import React					from 'react';										// eslint-disable-line no-unused-vars
 import renderer					from 'react-test-renderer';
 import getElementWithContext	from 'react-test-context-provider';					// for context provider
-import { ThemeProvider }		from '@material-ui/styles';							// for custom theme
-import CssBaseline				from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }		from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';					// for jss and reset.css
 
 import r3Theme					from '../../src/components/r3theme';				// custom theme
 import R3Progress				from '../../src/components/r3progress';
@@ -44,17 +44,19 @@ import { createNodeMock }		from '../__mocks__/materialUiMock';					// for materi
 //
 describe('R3Progress', () => {											// eslint-disable-line no-undef
 	it('test snapshot for R3Progress', () => {							// eslint-disable-line no-undef
-		/* eslint-disable indent */
 		const r3provider	= new R3Provider(null);
-		const element		= getElementWithContext({
-									r3Context:	r3provider.getR3Context()
-								},
-								<ThemeProvider theme={ r3Theme } >
-									<CssBaseline />
-									<R3Progress />
-								</ThemeProvider>
-							);
-		/* eslint-enable indent */
+
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3Progress />
+				</ThemeProvider>
+			</StyledEngineProvider>
+		);
 
 		const component = renderer.create(element, { createNodeMock });
 		let tree		= component.toJSON();

--- a/test/__tests__/r3resource-test.jsx
+++ b/test/__tests__/r3resource-test.jsx
@@ -22,8 +22,8 @@
 import React					from 'react';										// eslint-disable-line no-unused-vars
 import renderer					from 'react-test-renderer';
 import getElementWithContext	from 'react-test-context-provider';					// for context provider
-import { ThemeProvider }		from '@material-ui/styles';							// for custom theme
-import CssBaseline				from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }		from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';					// for jss and reset.css
 
 import r3Theme					from '../../src/components/r3theme';				// custom theme
 import R3Resource				from '../../src/components/r3resource';
@@ -83,24 +83,26 @@ const resource = {
 //
 describe('R3Resource', () => {											// eslint-disable-line no-undef
 	it('test snapshot for R3Resource', () => {							// eslint-disable-line no-undef
-		/* eslint-disable indent */
 		const r3provider	= new R3Provider(null);
-		const element		= getElementWithContext({
-									r3Context:	r3provider.getR3Context()
-								},
-								<ThemeProvider theme={ r3Theme } >
-									<CssBaseline />
-									<R3Resource
-										r3provider={ r3provider }
-										resource={ resource }
-										dispUnique={ 1 }
-										onSave={ save }
-										onUpdate={ update }
-										isReadMode={ false }
-									/>
-								</ThemeProvider>
-							);
-		/* eslint-enable indent */
+
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3Resource
+						r3provider={ r3provider }
+						resource={ resource }
+						dispUnique={ 1 }
+						onSave={ save }
+						onUpdate={ update }
+						isReadMode={ false }
+					/>
+				</ThemeProvider>
+			</StyledEngineProvider>
+		);
 
 		const component = renderer.create(element, { createNodeMock });
 		let tree		= component.toJSON();

--- a/test/__tests__/r3role-test.jsx
+++ b/test/__tests__/r3role-test.jsx
@@ -22,8 +22,8 @@
 import React					from 'react';										// eslint-disable-line no-unused-vars
 import renderer					from 'react-test-renderer';
 import getElementWithContext	from 'react-test-context-provider';					// for context provider
-import { ThemeProvider }		from '@material-ui/styles';							// for custom theme
-import CssBaseline				from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }		from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';					// for jss and reset.css
 
 import r3Theme					from '../../src/components/r3theme';				// custom theme
 import R3Role					from '../../src/components/r3role';
@@ -77,24 +77,26 @@ const role = {
 //
 describe('R3Role', () => {												// eslint-disable-line no-undef
 	it('test snapshot for R3Role', () => {								// eslint-disable-line no-undef
-		/* eslint-disable indent */
 		const r3provider	= new R3Provider(null);
-		const element		= getElementWithContext({
-									r3Context:	r3provider.getR3Context()
-								},
-								<ThemeProvider theme={ r3Theme } >
-									<CssBaseline />
-									<R3Role
-										r3provider={ r3provider }
-										role={ role }
-										dispUnique={ 1 }
-										onSave={ save }
-										onUpdate={ update }
-										isReadMode={ false }
-									/>
-								</ThemeProvider>
-							);
-		/* eslint-enable indent */
+
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3Role
+						r3provider={ r3provider }
+						role={ role }
+						dispUnique={ 1 }
+						onSave={ save }
+						onUpdate={ update }
+						isReadMode={ false }
+					/>
+				</ThemeProvider>
+			</StyledEngineProvider>
+		);
 
 		const component = renderer.create(element, { createNodeMock });
 		let tree		= component.toJSON();

--- a/test/__tests__/r3service-test.jsx
+++ b/test/__tests__/r3service-test.jsx
@@ -22,8 +22,8 @@
 import React					from 'react';										// eslint-disable-line no-unused-vars
 import renderer					from 'react-test-renderer';
 import getElementWithContext	from 'react-test-context-provider';					// for context provider
-import { ThemeProvider }		from '@material-ui/styles';							// for custom theme
-import CssBaseline				from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }		from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';					// for jss and reset.css
 
 import r3Theme					from '../../src/components/r3theme';				// custom theme
 import R3Service				from '../../src/components/r3service';
@@ -74,24 +74,26 @@ const service = {
 //
 describe('R3Service', () => {											// eslint-disable-line no-undef
 	it('test snapshot for R3Service', () => {							// eslint-disable-line no-undef
-		/* eslint-disable indent */
 		const r3provider	= new R3Provider(null);
-		const element		= getElementWithContext({
-									r3Context:	r3provider.getR3Context()
-								},
-								<ThemeProvider theme={ r3Theme } >
-									<CssBaseline />
-									<R3Service
-										tenant={ 'JEST_TENANT_NAME' }
-										service={ service }
-										dispUnique={ 1 }
-										r3provider={ r3provider }
-										onSave={ save }
-										onUpdate={ update }
-									/>
-								</ThemeProvider>
-							);
-		/* eslint-enable indent */
+
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3Service
+						tenant={ 'JEST_TENANT_NAME' }
+						service={ service }
+						dispUnique={ 1 }
+						r3provider={ r3provider }
+						onSave={ save }
+						onUpdate={ update }
+					/>
+				</ThemeProvider>
+			</StyledEngineProvider>
+		);
 
 		const component = renderer.create(element, { createNodeMock });
 		let tree		= component.toJSON();

--- a/test/__tests__/r3signincreddialog-test.jsx
+++ b/test/__tests__/r3signincreddialog-test.jsx
@@ -22,11 +22,11 @@
 import React					from 'react';										// eslint-disable-line no-unused-vars
 import renderer					from 'react-test-renderer';
 import getElementWithContext	from 'react-test-context-provider';					// for context provider
-import { ThemeProvider }		from '@material-ui/styles';							// for custom theme
-import CssBaseline				from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }		from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';					// for jss and reset.css
 
 import r3Theme					from '../../src/components/r3theme';				// custom theme
-import Rr3SigninCredDialog		from '../../src/components/r3signincreddialog';
+import R3SigninCredDialog		from '../../src/components/r3signincreddialog';
 import R3Provider				from '../../src/util/r3provider';
 
 import mock_fetch				from '../__mocks__/fetchMock';						// eslint-disable-line no-unused-vars
@@ -76,10 +76,10 @@ r3Theme.r3SigninCredDialog.root['disablePortal'] = true;
 // Unlike before, by changing the mock content, you can fully check
 // the snapshots in the Dialog.
 //
-jest.mock('@material-ui/core/Fade', () => {												// eslint-disable-line no-undef
+jest.mock('@mui/material/Fade', () => {												// eslint-disable-line no-undef
 	return '';
 });
-jest.mock('@material-ui/core/Modal', () => {											// eslint-disable-line no-undef
+jest.mock('@mui/material/Modal', () => {											// eslint-disable-line no-undef
 	return '';
 });
 
@@ -110,25 +110,27 @@ describe('R3CreateServiceDialog', () => {											// eslint-disable-line no-un
 		ReactDOM.createPortal.mockClear();
 	});
 
-	it('test snapshot for Rr3SigninCredDialog', () => {								// eslint-disable-line no-undef
-		/* eslint-disable indent */
+	it('test snapshot for R3SigninCredDialog', () => {								// eslint-disable-line no-undef
 		const r3provider	= new R3Provider(null);
-		const element		= getElementWithContext({
-									r3Context:	r3provider.getR3Context()
-								},
-								<ThemeProvider theme={ r3Theme } >
-									<CssBaseline />
-									<Rr3SigninCredDialog
-										r3provider={ r3provider }
-										open={ true }
-										name={ null }
-										passphrase={ null }
-										message={ null }
-										onClose={ close }
-									/>
-								</ThemeProvider>
-							);
-		/* eslint-enable indent */
+
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3SigninCredDialog
+						r3provider={ r3provider }
+						open={ true }
+						name={ null }
+						passphrase={ null }
+						message={ null }
+						onClose={ close }
+					/>
+				</ThemeProvider>
+			</StyledEngineProvider>
+		);
 
 		const component = renderer.create(element, { createNodeMock });
 		let tree		= component.toJSON();

--- a/test/__tests__/r3toolbar-test.jsx
+++ b/test/__tests__/r3toolbar-test.jsx
@@ -22,8 +22,8 @@
 import React					from 'react';										// eslint-disable-line no-unused-vars
 import renderer					from 'react-test-renderer';
 import getElementWithContext	from 'react-test-context-provider';					// for context provider
-import { ThemeProvider }		from '@material-ui/styles';							// for custom theme
-import CssBaseline				from '@material-ui/core/CssBaseline';				// for reset.css
+import { ThemeProvider }		from '@mui/styles';									// for custom theme
+import { StyledEngineProvider, CssBaseline}	from '@mui/material';					// for jss and reset.css
 
 import r3Theme					from '../../src/components/r3theme';				// custom theme
 import R3Toolbar				from '../../src/components//r3toolbar';
@@ -84,29 +84,30 @@ const userdata = {
 //
 describe('R3ToolBar', () => {											// eslint-disable-line no-undef
 	it('test snapshot for R3ToolBar', () => {							// eslint-disable-line no-undef
-		/* eslint-disable indent */
-		const element		= getElementWithContext({
-									r3Context:	r3provider.getR3Context()
-								},
-								<ThemeProvider theme={ r3Theme } >
-									<CssBaseline />
-									<R3Toolbar
-										toolbarData={ toolbardata }
-										r3provider={ r3provider }
-										userData={ userdata }
-										onArrawUpward={ ArrawUpward }
-										onCreatePath={ CreatePath }
-										onCheckPath={ CheckPath }
-										onDeletePath={ DeletePath }
-										onCreateService={ CreateService }
-										onCreateServiceTenant={ CreateServiceTenant }
-										onCheckServiceName={ CheckServiceName }
-										onDeleteService={ DeleteService }
-										onCheckUpdating={ CheckUpdating }
-									/>
-								</ThemeProvider>
-							);
-		/* eslint-enable indent */
+		const element		= getElementWithContext(
+			{
+				r3Context:	r3provider.getR3Context()
+			},
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={ r3Theme } >
+					<CssBaseline />
+					<R3Toolbar
+						toolbarData={ toolbardata }
+						r3provider={ r3provider }
+						userData={ userdata }
+						onArrawUpward={ ArrawUpward }
+						onCreatePath={ CreatePath }
+						onCheckPath={ CheckPath }
+						onDeletePath={ DeletePath }
+						onCreateService={ CreateService }
+						onCreateServiceTenant={ CreateServiceTenant }
+						onCheckServiceName={ CheckServiceName }
+						onDeleteService={ DeleteService }
+						onCheckUpdating={ CheckUpdating }
+					/>
+				</ThemeProvider>
+			</StyledEngineProvider>
+		);
 
 		const component = renderer.create(element, { createNodeMock });
 		let tree		= component.toJSON();


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
k2hr3_app used Material-ui v4, but Material-ui has been changed to MUI(renamed), and MUI v5 was the latest, so k2hr3_app corresponded to v5.
Also, React packages upgraded from using React 16 base to React 17 for corresponding to  MUI v5.

#### NOTE
Since `@mui/styles` was used in k2hr3_app after the migration from MUI v4 to v5 yet, we could not be migrated to React 18.
