### PR TITLE
Fixed a bug about setting CA certification

### DIFF
--- a/routes/lib/libr3tokens.js
+++ b/routes/lib/libr3tokens.js
@@ -23,6 +23,7 @@
 
 var	r3util		= require('./libr3util');
 var	appConfig	= require('./libr3appconfig').r3AppConfig;
+var	fs			= require('fs');
 
 //---------------------------------------------------------
 // User Token Class
@@ -148,6 +149,12 @@ var R3UserToken = (function()
 						};
 		if(secure){
 			options.agent	= agent;
+
+			// Set CA cert file
+			var ca = this.appConfig.getCA();
+			if(r3util.isSafeString(ca)){
+				options.ca = [ fs.readFileSync(ca, {encoding: 'utf-8'}) ];
+			}
 		}
 		/* eslint-enable indent, no-mixed-spaces-and-tabs */
 


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
Specify the CA certificate when accessing the K2HR3 API when specifying the CA certificate in the configuration file.